### PR TITLE
[SuperReader][SuperReader][iOS] Fix crash when pushing a route with a delegatedTransition. (Resolves #2794)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -1516,7 +1516,13 @@ class SuperEditorIosToolbarOverlayManagerState extends State<SuperEditorIosToolb
     super.didChangeDependencies();
 
     _controlsController = SuperEditorIosControlsScope.rootOf(context);
-    _overlayPortalController.show();
+
+    // It's possible that `didChangeDependencies` is called during build when pushing a route
+    // that has a delegated transition. We need to wait until the next frame to show the overlay,
+    // otherwise this widget crashes, since we can't call `OverlayPortalController.show` during build.
+    onNextFrame((timeStamp) {
+      _overlayPortalController.show();
+    });
   }
 
   @visibleForTesting
@@ -1578,7 +1584,13 @@ class SuperEditorIosMagnifierOverlayManagerState extends State<SuperEditorIosMag
   void didChangeDependencies() {
     super.didChangeDependencies();
     _controlsController = SuperEditorIosControlsScope.rootOf(context);
-    _overlayPortalController.show();
+
+    // It's possible that `didChangeDependencies` is called during build when pushing a route
+    // that has a delegated transition. We need to wait until the next frame to show the overlay,
+    // otherwise this widget crashes, since we can't call `OverlayPortalController.show` during build.
+    onNextFrame((timeStamp) {
+      _overlayPortalController.show();
+    });
   }
 
   @override

--- a/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
@@ -1077,7 +1077,13 @@ class SuperReaderIosToolbarOverlayManagerState extends State<SuperReaderIosToolb
     super.didChangeDependencies();
 
     _controlsContext = SuperReaderIosControlsScope.rootOf(context);
-    _overlayPortalController.show();
+
+    // It's possible that `didChangeDependencies` is called during build when pushing a route
+    // that has a delegated transition. We need to wait until the next frame to show the overlay,
+    // otherwise this widget crashes, since we can't call `OverlayPortalController.show` during build.
+    onNextFrame((timeStamp) {
+      _overlayPortalController.show();
+    });
   }
 
   @override
@@ -1138,7 +1144,12 @@ class SuperReaderIosMagnifierOverlayManagerState extends State<SuperReaderIosMag
 
     _controlsContext = SuperReaderIosControlsScope.rootOf(context);
 
-    _overlayPortalController.show();
+    // It's possible that `didChangeDependencies` is called during build when pushing a route
+    // that has a delegated transition. We need to wait until the next frame to show the overlay,
+    // otherwise this widget crashes, since we can't call `OverlayPortalController.show` during build.
+    onNextFrame((timeStamp) {
+      _overlayPortalController.show();
+    });
   }
 
   @override

--- a/super_editor/test/super_editor/supereditor_route_test.dart
+++ b/super_editor/test/super_editor/supereditor_route_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+
+import 'supereditor_test_tools.dart';
+
+void main() {
+  group('SuperEditor > routes >', () {
+    testWidgetsOnAllPlatforms('can be used with a route with a delegated transition on top', (tester) async {
+      await tester //
+          .createDocument()
+          .withSingleParagraph()
+          .withCustomWidgetTreeBuilder(
+            (superEditor) => MaterialApp(
+              home: Scaffold(
+                body: Column(
+                  children: [
+                    Expanded(
+                      child: superEditor,
+                    ),
+                    Builder(builder: (context) {
+                      return ElevatedButton(
+                        child: const Text('delegatedTransition'),
+                        onPressed: () {
+                          Navigator.of(context).push(_TestRoute());
+                        },
+                      );
+                    }),
+                  ],
+                ),
+              ),
+            ),
+          )
+          .pump();
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pump();
+
+      // Reaching this point means that the editor did not crash when the route with
+      // a delegated transition was pushed on top of it.
+      // See https://github.com/Flutter-Bounty-Hunters/super_editor/issues/2794 for details.
+    });
+  });
+}
+
+/// A [ModalRoute] that uses a delegated transition.
+class _TestRoute extends ModalRoute<void> {
+  _TestRoute();
+
+  @override
+  DelegatedTransitionBuilder? get delegatedTransition =>
+      (context, animation, secondaryAnimation, allowSnapshotting, child) {
+        return FadeTransition(
+          opacity: animation,
+          child: child,
+        );
+      };
+
+  @override
+  Color? get barrierColor => null;
+
+  @override
+  String? get barrierLabel => null;
+
+  @override
+  bool get barrierDismissible => true;
+
+  @override
+  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
+    return const Center(
+      child: Text('Hello'),
+    );
+  }
+
+  @override
+  bool get maintainState => true;
+
+  @override
+  bool get opaque => false;
+
+  @override
+  Duration get transitionDuration => const Duration(milliseconds: 300);
+}

--- a/super_editor/test/super_reader/super_reader_route_test.dart
+++ b/super_editor/test/super_reader/super_reader_route_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+
+import 'reader_test_tools.dart';
+
+void main() {
+  group('SuperReader > routes >', () {
+    testWidgetsOnAllPlatforms('can be used with a route with a delegated transition on top', (tester) async {
+      await tester //
+          .createDocument()
+          .withSingleParagraph()
+          .withCustomWidgetTreeBuilder(
+            (superReader) => MaterialApp(
+              home: Scaffold(
+                body: Column(
+                  children: [
+                    Expanded(
+                      child: superReader,
+                    ),
+                    Builder(builder: (context) {
+                      return ElevatedButton(
+                        child: const Text('delegatedTransition'),
+                        onPressed: () {
+                          Navigator.of(context).push(_TestRoute());
+                        },
+                      );
+                    }),
+                  ],
+                ),
+              ),
+            ),
+          )
+          .pump();
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pump();
+
+      // Reaching this point means that the reader did not crash when the route with
+      // a delegated transition was pushed on top of it.
+      // See https://github.com/Flutter-Bounty-Hunters/super_editor/issues/2794 for details.
+    });
+  });
+}
+
+/// A [ModalRoute] that uses a delegated transition.
+class _TestRoute extends ModalRoute<void> {
+  _TestRoute();
+
+  @override
+  DelegatedTransitionBuilder? get delegatedTransition =>
+      (context, animation, secondaryAnimation, allowSnapshotting, child) {
+        return FadeTransition(
+          opacity: animation,
+          child: child,
+        );
+      };
+
+  @override
+  Color? get barrierColor => null;
+
+  @override
+  String? get barrierLabel => null;
+
+  @override
+  bool get barrierDismissible => true;
+
+  @override
+  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
+    return const Center(
+      child: Text('Hello'),
+    );
+  }
+
+  @override
+  bool get maintainState => true;
+
+  @override
+  bool get opaque => false;
+
+  @override
+  Duration get transitionDuration => const Duration(milliseconds: 300);
+}


### PR DESCRIPTION
[SuperReader][SuperReader][iOS] Fix crash when pushing a route with a delegatedTransition. (Resolves #2794)

On iOS, attempting to push any route that has a `delegatedTransition` over a route that contains `SuperEditor` or `SuperReader` causes a crash with the following exception:

```console
════════ Exception caught by widgets library ═══════════════════════════════════

OverlayPortalController.show() should not be called during build.

'package:flutter/src/widgets/overlay.dart':

Failed assertion: line 1968 pos 7: 'SchedulerBinding.instance.schedulerPhase != SchedulerPhase.persistentCallbacks'

The relevant error-causing widget was:

    SuperEditorIosToolbarOverlayManager SuperEditorIosToolbarOverlayManager:file:///Users/angelosilvestre/dev/super_editor/super_editor/lib/src/default_editor/super_editor.dart:828:16

════════════════════════════════════════════════════════════════════════════════

```

The issue is that we call `OverlayPortalController.show()` in the `didChangeDependencies` callback, which is called during build.

This PR fixes the issue by deferring the call to `OverlayPortalController.show()` to the end of the frame. The issue is not happening on Android.