### PR TITLE
fix: bring task default styles in line with numbered/unordered list

### DIFF
--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -1725,6 +1725,14 @@ final defaultStylesheet = Stylesheet(
       },
     ),
     StyleRule(
+      const BlockSelector("task"),
+      (doc, docNode) {
+        return {
+          Styles.padding: const CascadingPadding.only(top: 24),
+        };
+      },
+    ),
+    StyleRule(
       const BlockSelector("blockquote"),
       (doc, docNode) {
         return {


### PR DESCRIPTION
Tasks have inconsistent styling compared with numbered/unordered lists. This fixes that