### PR TITLE
Fix/markdown deserialize list indented after task

### DIFF
--- a/super_editor/lib/src/infrastructure/serialization/markdown/document_to_markdown_serializer.dart
+++ b/super_editor/lib/src/infrastructure/serialization/markdown/document_to_markdown_serializer.dart
@@ -261,9 +261,11 @@ class ListItemNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<Lis
 
     final nodeIndex = document.getNodeIndexById(node.id);
     final nodeBelow = nodeIndex < document.nodeCount - 1 ? document.getNodeAt(nodeIndex + 1) : null;
-    if (nodeBelow != null && (nodeBelow is! ListItemNode || nodeBelow.type != node.type)) {
-      // This list item is the last item in the list. Add an extra
-      // blank line after it.
+    final isSameListType = nodeBelow is ListItemNode && nodeBelow.type == node.type;
+    final isFollowedByTask = nodeBelow is TaskNode;
+    if (nodeBelow != null && !isSameListType && !isFollowedByTask) {
+      // This list item is the last item in the list and is not followed by a task.
+      // Add an extra blank line after it.
       buffer.writeln('');
     }
 
@@ -375,7 +377,7 @@ class TaskNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<TaskNod
         ? node.text.copyText(textSelection.start, textSelection.end)
         : node.text;
 
-    return '- [${node.isComplete ? 'x' : ' '}] ${textToConvert.toMarkdown()}';
+    return '  - [${node.isComplete ? 'x' : ' '}] ${textToConvert.toMarkdown()}';
   }
 }
 

--- a/super_editor/test/infrastructure/serialization/markdown/super_editor_markdown_pasting_test.dart
+++ b/super_editor/test/infrastructure/serialization/markdown/super_editor_markdown_pasting_test.dart
@@ -446,5 +446,5 @@ Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tort
 
 Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.
 
-- [ ] This is an incomplete task
-- [x] This is a completed task''';
+  - [ ] This is an incomplete task
+  - [x] This is a completed task''';

--- a/super_editor/test/infrastructure/serialization/markdown/super_editor_markdown_test.dart
+++ b/super_editor/test/infrastructure/serialization/markdown/super_editor_markdown_test.dart
@@ -1491,6 +1491,32 @@ with multiple lines
         expect((document.getNodeAt(3)! as TaskNode).isComplete, isTrue);
       });
 
+      test('round-trip mixed list items and tasks', () {
+        const markdown = '''  * First item
+  - [ ] A task
+  * Second item''';
+
+        final document = deserializeMarkdownToDocument(markdown);
+
+        expect(document.nodeCount, 3);
+
+        expect(document.getNodeAt(0), isA<ListItemNode>());
+        expect((document.getNodeAt(0) as ListItemNode).text.toPlainText(), 'First item');
+        expect((document.getNodeAt(0) as ListItemNode).type, ListItemType.unordered);
+
+        expect(document.getNodeAt(1), isA<TaskNode>());
+        expect((document.getNodeAt(1) as TaskNode).text.toPlainText(), 'A task');
+        expect((document.getNodeAt(1) as TaskNode).isComplete, isFalse);
+
+        expect(document.getNodeAt(2), isA<ListItemNode>());
+        expect((document.getNodeAt(2) as ListItemNode).text.toPlainText(), 'Second item');
+        expect((document.getNodeAt(2) as ListItemNode).type, ListItemType.unordered);
+
+        final serialized = serializeDocumentToMarkdown(document);
+
+        expect(serialized, markdown);
+      });
+
       test('example doc 1', () {
         final document = deserializeMarkdownToDocument(exampleMarkdownDoc1);
 

--- a/super_editor/test/infrastructure/serialization/markdown/super_editor_markdown_test.dart
+++ b/super_editor/test/infrastructure/serialization/markdown/super_editor_markdown_test.dart
@@ -1517,6 +1517,40 @@ with multiple lines
         expect(serialized, markdown);
       });
 
+      test('mixed list items and tasks with nested list item under task', () {
+        const markdown = '''  * List item
+  - [ ] Task
+    * List item 2
+  * List item 3''';
+
+        final document = deserializeMarkdownToDocument(markdown);
+
+        expect(document.nodeCount, 4);
+
+        // First list item at indent 0
+        expect(document.getNodeAt(0), isA<ListItemNode>());
+        expect((document.getNodeAt(0) as ListItemNode).text.toPlainText(), 'List item');
+        expect((document.getNodeAt(0) as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(0) as ListItemNode).indent, 0);
+
+        // Task at indent 0
+        expect(document.getNodeAt(1), isA<TaskNode>());
+        expect((document.getNodeAt(1) as TaskNode).text.toPlainText(), 'Task');
+        expect((document.getNodeAt(1) as TaskNode).isComplete, isFalse);
+
+        // Nested list item at indent 1
+        expect(document.getNodeAt(2), isA<ListItemNode>());
+        expect((document.getNodeAt(2) as ListItemNode).text.toPlainText(), 'List item 2');
+        expect((document.getNodeAt(2) as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(2) as ListItemNode).indent, 1);
+
+        // List item at indent 0
+        expect(document.getNodeAt(3), isA<ListItemNode>());
+        expect((document.getNodeAt(3) as ListItemNode).text.toPlainText(), 'List item 3');
+        expect((document.getNodeAt(3) as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(3) as ListItemNode).indent, 0);
+      });
+
       test('example doc 1', () {
         final document = deserializeMarkdownToDocument(exampleMarkdownDoc1);
 

--- a/super_editor/test/infrastructure/serialization/markdown/super_editor_markdown_test.dart
+++ b/super_editor/test/infrastructure/serialization/markdown/super_editor_markdown_test.dart
@@ -747,11 +747,11 @@ Paragraph3""");
         expect(
           serializeDocumentToMarkdown(doc),
           '''
-- [x] Task 1
-- [ ] Task 2  
+  - [x] Task 1
+  - [ ] Task 2  
 with multiple lines
-- [ ] Task 3
-- [x] Task 4''',
+  - [ ] Task 3
+  - [x] Task 4''',
         );
       });
 
@@ -764,7 +764,7 @@ with multiple lines
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc), '- [ ] **Task** 1');
+        expect(serializeDocumentToMarkdown(doc), '  - [ ] **Task** 1');
       });
 
       test('example doc', () {


### PR DESCRIPTION
Indented lists after tasks were broken

Given 
- [ ] Task
   - List item
- List item 2

This generated

Task: TaskList Item
ListItem: List item 2