### PR TITLE
Add `updateStyle` method to `TextInputConnectionDecorator`

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/ime_decoration.dart
+++ b/super_editor/lib/src/default_editor/document_ime/ime_decoration.dart
@@ -49,6 +49,9 @@ abstract class TextInputConnectionDecorator implements TextInputConnection {
           textAlign: textAlign);
 
   @override
+  void updateStyle(TextInputStyle style) => client?.updateStyle(style);
+
+  @override
   void requestAutofill() => client?.requestAutofill();
 
   @override

--- a/super_editor_clipboard/pubspec.yaml
+++ b/super_editor_clipboard/pubspec.yaml
@@ -18,9 +18,9 @@ dependencies:
   super_editor: ^0.3.0-dev.48
   super_keyboard: ^0.3.1
 
-#dependency_overrides:
-#  super_editor:
-#    path: ../super_editor
+dependency_overrides:
+ super_editor:
+   path: ../super_editor
 #  super_editor_markdown:
 #    path: ../super_editor_markdown
 #  super_keyboard:

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -24,9 +24,9 @@ dependencies:
   markdown: ^7.2.1
   collection: ^1.15.0
 
-#dependency_overrides:
-#  # Override to local mono-repo path so devs can test this repo
-#  # against changes that they're making to other mono-repo packages
+dependency_overrides:
+ # Override to local mono-repo path so devs can test this repo
+ # against changes that they're making to other mono-repo packages
  super_editor:
    path: ../super_editor
 #  super_text_layout:

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -27,8 +27,8 @@ dependencies:
 #dependency_overrides:
 #  # Override to local mono-repo path so devs can test this repo
 #  # against changes that they're making to other mono-repo packages
-#  super_editor:
-#    path: ../super_editor
+ super_editor:
+   path: ../super_editor
 #  super_text_layout:
 #    path: ../super_text_layout
 #  attributed_text:

--- a/super_editor_quill/pubspec.yaml
+++ b/super_editor_quill/pubspec.yaml
@@ -32,9 +32,9 @@ dependencies:
   matcher: ^0.12.16+1
   text_table: ^4.0.3
 
-#dependency_overrides:
-#  super_editor:
-#    path: ../super_editor
+dependency_overrides:
+ super_editor:
+   path: ../super_editor
 #  super_text_layout:
 #    path: ../super_text_layout
 #  attributed_text:


### PR DESCRIPTION
In https://github.com/flutter/flutter/pull/180436 a breaking change was introduced to pass additional styling information to the web engine in order to fix https://github.com/flutter/flutter/issues/161592. Historically the framework passes this information using `TextInputConnection.setStyle(......)`, however after the breaking change the framework introduced `TextInputConnection.updateStyle(TextInputStyle style)` and deprecated the old method in an effort to minimize future breaking changes when passing additional style parameters to the engine.

This change fixes the breakage by adding an implementation for the new method added `TextInputConnection.updateStyle`.

A full migration to `updateStyle` in addition to providing the additional styling information to the web engine will still be needed if experiencing https://github.com/flutter/flutter/issues/161592.