### PR TITLE
[super_editor] super_message | contentTapDelegate not passed to SuperMessageAndroidTouchInteractor

### DIFF
--- a/super_editor/lib/src/chat/super_message.dart
+++ b/super_editor/lib/src/chat/super_message.dart
@@ -373,6 +373,7 @@ class _SuperMessageState extends State<SuperMessage> {
                 focusNode: _focusNode,
                 editor: widget.editor,
                 getDocumentLayout: () => _messageContext.documentLayout,
+                contentTapHandlers: _contentTapDelegate != null ? [_contentTapDelegate!] : null,
                 showDebugPaint: widget.debugPaint.gestures,
                 child: SuperMessageAndroidControlsOverlayManager(
                   editor: widget.editor,


### PR DESCRIPTION
Problem: 
- Tap gestures are not being registered on Android only.
Solution: 
- Pass _contentTapDelegate to SuperMessageAndroidTouchInteractor (which is being correctly passed to SuperMessageIosTouchInteractor) 