### PR TITLE
[Chat] - Don't dismiss SuperMessage toolbar on 'Select All' (Resolves #2957)

### DIFF
--- a/super_editor/lib/src/chat/super_message_android_overlays.dart
+++ b/super_editor/lib/src/chat/super_message_android_overlays.dart
@@ -892,8 +892,6 @@ class DefaultAndroidSuperMessageToolbar extends StatelessWidget {
         SelectionReason.userInteraction,
       ),
     ]);
-
-    messageControlsController.hideToolbar();
   }
 
   Future<void> _saveToClipboard(String text) {

--- a/super_editor/lib/src/chat/super_message_ios_overlays.dart
+++ b/super_editor/lib/src/chat/super_message_ios_overlays.dart
@@ -355,8 +355,6 @@ class DefaultIOSSuperMessageToolbar extends StatelessWidget {
         SelectionReason.userInteraction,
       ),
     ]);
-
-    messageControlsController.hideToolbar();
   }
 
   Future<void> _saveToClipboard(String text) {

--- a/super_editor/test/chat/super_message_toolbar_test.dart
+++ b/super_editor/test/chat/super_message_toolbar_test.dart
@@ -22,7 +22,7 @@ void main() {
         expect(find.byType(DefaultIOSSuperMessageToolbar), findsNothing);
       });
 
-      testWidgetsOnIos("dismisses after select-all button is pressed", (tester) async {
+      testWidgetsOnIos("does not dismiss after select-all button is pressed", (tester) async {
         await _pumpScaffold(tester);
 
         // Long press to select text and show the toolbar.
@@ -34,7 +34,7 @@ void main() {
         await tester.pump();
 
         // Ensure toolbar is dismissed.
-        expect(find.byType(DefaultIOSSuperMessageToolbar), findsNothing);
+        expect(find.byType(DefaultIOSSuperMessageToolbar), findsOne);
       });
     });
 
@@ -54,7 +54,7 @@ void main() {
         expect(find.byType(DefaultAndroidSuperMessageToolbar), findsNothing);
       });
 
-      testWidgetsOnAndroid("dismisses after select-all button is pressed", (tester) async {
+      testWidgetsOnAndroid("does not dismiss after select-all button is pressed", (tester) async {
         await _pumpScaffold(tester);
 
         // Long press to select text and show the toolbar.
@@ -66,7 +66,7 @@ void main() {
         await tester.pump();
 
         // Ensure toolbar is dismissed.
-        expect(find.byType(DefaultAndroidSuperMessageToolbar), findsNothing);
+        expect(find.byType(DefaultAndroidSuperMessageToolbar), findsOne);
       });
     });
   });


### PR DESCRIPTION
[Chat] - Don't dismiss SuperMessage toolbar on 'Select All' (Resolves #2957)