### PR TITLE
[Super Editor][IME][Bug]: Fix zombie IME client when switching from one SuperEditor instance to a replacement SuperEditor instance (Resolve #2965)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_ime_interaction_policies.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_ime_interaction_policies.dart
@@ -110,22 +110,24 @@ class _ImeFocusPolicyState extends State<ImeFocusPolicy> {
       return;
     }
 
+    var didTakeOwnership = false;
     if (_focusNode.hasFocus && !SuperIme.instance.isOwner(widget.inputId)) {
       // We have focus but we don't own the IME. Take it over.
       SuperIme.instance.takeOwnership(widget.inputId);
+      didTakeOwnership = true;
     }
 
     bool shouldOpenIme = false;
     if (_focusNode.hasPrimaryFocus &&
         widget.openImeOnPrimaryFocusGain &&
-        !SuperIme.instance.isInputAttachedToOS(widget.inputId)) {
+        (!SuperIme.instance.isInputAttachedToOS(widget.inputId) || didTakeOwnership)) {
       editorPoliciesLog
           .info("[${widget.runtimeType}] - Document editor gained primary focus. Opening an IME connection.");
       shouldOpenIme = true;
     } else if (!_focusNode.hasPrimaryFocus &&
         _focusNode.hasFocus &&
         widget.openImeOnNonPrimaryFocusGain &&
-        !SuperIme.instance.isInputAttachedToOS(widget.inputId)) {
+        (!SuperIme.instance.isInputAttachedToOS(widget.inputId) || didTakeOwnership)) {
       editorPoliciesLog
           .info("[${widget.runtimeType}] - Document editor gained non-primary focus. Opening an IME connection.");
       shouldOpenIme = true;
@@ -356,11 +358,13 @@ class _DocumentSelectionOpenAndCloseImePolicyState extends State<DocumentSelecti
     if (widget.selection.value != null && widget.focusNode.hasPrimaryFocus && widget.openKeyboardOnSelectionChange) {
       // There's a new document selection, and our policy wants the keyboard to be
       // displayed whenever the selection changes. Show the keyboard.
+      var didTakeOwnership = false;
       if (!SuperIme.instance.isOwner(widget.inputId)) {
         SuperIme.instance.takeOwnership(widget.inputId);
+        didTakeOwnership = true;
       }
 
-      if (!SuperIme.instance.isInputAttachedToOS(widget.inputId)) {
+      if (!SuperIme.instance.isInputAttachedToOS(widget.inputId) || didTakeOwnership) {
         WidgetsBinding.instance.runAsSoonAsPossible(() {
           if (!mounted) {
             return;

--- a/super_editor/lib/src/default_editor/document_ime/ime_decoration.dart
+++ b/super_editor/lib/src/default_editor/document_ime/ime_decoration.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 
@@ -82,7 +83,10 @@ class DeltaTextInputClientDecorator with TextInputClient, DeltaTextInputClient {
   /// itself as the client, or not.
   bool isCurrentClient(DeltaTextInputClient client) => _client == client;
 
-  set client(DeltaTextInputClient? client) => _client = client;
+  set client(DeltaTextInputClient? client) {
+    _client = client;
+  }
+
   DeltaTextInputClient? _client;
 
   @override

--- a/super_editor/lib/src/default_editor/document_ime/shared_ime.dart
+++ b/super_editor/lib/src/default_editor/document_ime/shared_ime.dart
@@ -19,6 +19,7 @@ class SuperIme with ChangeNotifier {
   SuperImeInputId? _owner;
 
   TextInputConnection? _imeConnection;
+  TextInputClient? _attachedClient;
 
   /// Returns `true` if [SuperIme] currently holds a Flutter [TextInputConnection]
   /// in [imeConnection].
@@ -37,6 +38,8 @@ class SuperIme with ChangeNotifier {
   /// Returns `true` if the given [input] is the current owner of the shared IME,
   /// and the shared IME is currently attached to the OS.
   bool isInputAttachedToOS(SuperImeInputId input) => _owner == input && isAttachedToOS;
+
+  TextInputClient? get attachedClient => _attachedClient;
 
   /// If [owner] is the current IME owner, returns the shared [TextInputConnection], or `null` if
   /// no such connection currently exists, or if the [owner] isn't actually the owner.
@@ -73,7 +76,10 @@ class SuperIme with ChangeNotifier {
     }
 
     superImeLog.info("Opening IME connection (owner: '$ownerInputId')");
-    _imeConnection ??= TextInput.attach(client, configuration);
+    if (_imeConnection == null || client != _attachedClient) {
+      _imeConnection = TextInput.attach(client, configuration);
+    }
+    _attachedClient = client;
     if (showKeyboard) {
       _imeConnection!.show();
     }
@@ -89,8 +95,10 @@ class SuperIme with ChangeNotifier {
     }
 
     superImeLog.info("Closing IME connection (owner: '$ownerInputId')");
+    print("Closing IME connection (owner: '$ownerInputId')");
     _imeConnection?.close();
     _imeConnection = null;
+    _attachedClient = null;
 
     notifyListeners();
   }

--- a/super_editor/lib/src/default_editor/document_ime/shared_ime.dart
+++ b/super_editor/lib/src/default_editor/document_ime/shared_ime.dart
@@ -14,11 +14,35 @@ class SuperIme with ChangeNotifier {
 
   SuperIme._();
 
+  /// Sets the [SuperImeLog], which is notified of important events that take
+  /// place within this [SuperIme], e.g., taking ownership, releasing ownership,
+  /// opening a connection, closing a connection.
+  set log(SuperImeLog? log) => _log = log;
+  SuperImeLog? _log = SuperImeLog();
+
   /// The current owner of the IME, or `null` if there is no owner.
   SuperImeInputId? get owner => _owner;
   SuperImeInputId? _owner;
 
+  /// The open OS IME connection, which is owned by [owner], but *may* have been
+  /// opened by a previous owner.
   TextInputConnection? _imeConnection;
+
+  /// The [SuperImeInputId] that was the owner when the [_imeConnection] was opened,
+  /// which may not be the same as [owner], if a different owner took ownership and
+  /// kept the connection open.
+  // TODO: Find out which scenarios would ever want to take new ownership, but leave the
+  //       existing connection open. If we find them, document them. If we can't find them,
+  //       then change `releaseOwnership()` to automatically close the open connection.
+  SuperImeInputId? _connectionOwner;
+
+  /// The [TextInputClient] that was passed to Flutter when opening the current
+  /// [_imeConnection].
+  ///
+  /// We track this so that we know when the client changes, which requires us to
+  /// close the current connection and open a new connection. This is because Flutter
+  /// registers the IME client when the connection is opened, and it cannot be change
+  /// or replaced after that.
   TextInputClient? _attachedClient;
 
   /// Returns `true` if [SuperIme] currently holds a Flutter [TextInputConnection]
@@ -39,6 +63,12 @@ class SuperIme with ChangeNotifier {
   /// and the shared IME is currently attached to the OS.
   bool isInputAttachedToOS(SuperImeInputId input) => _owner == input && isAttachedToOS;
 
+  /// Returns the [TextInputClient] that is currently connected to the open IME
+  /// connection.
+  ///
+  /// This client is made available for instance verification. It's not expected that
+  /// apps call anything on this client. Doing so could corrupt the accounting between
+  /// the client and the OS IME state.
   TextInputClient? get attachedClient => _attachedClient;
 
   /// If [owner] is the current IME owner, returns the shared [TextInputConnection], or `null` if
@@ -75,11 +105,28 @@ class SuperIme with ChangeNotifier {
       _imeConnection = null;
     }
 
-    superImeLog.info("Opening IME connection (owner: '$ownerInputId')");
     if (_imeConnection == null || client != _attachedClient) {
+      // Log the specific action we're taking here, because its nuanced and we will
+      // want to know which one we did, if a bug shows up.
+      if (_imeConnection == null) {
+        // We're opening a new connection. There was no previous connection.
+        _log?.onNewImeConnectionOpened(ownerInputId);
+      } else if (_owner?.role != ownerInputId.role) {
+        // The owner changed from one role to another, which means one editor to a
+        // completely different editor.
+        _log?.onImeConnectionSwitchedBetweenRoles(previousOwner: _connectionOwner!, newOwner: ownerInputId);
+      } else {
+        // The owner didn't change role, but did change instance. This means the owner
+        // is playing the same role (same editor), but is a different instance (different
+        // `State` object).
+        _log?.onImeConnectionSwitchedBetweenInstances(previousOwner: _connectionOwner!, newOwner: ownerInputId);
+      }
+
       _imeConnection = TextInput.attach(client, configuration);
     }
     _attachedClient = client;
+    _connectionOwner = ownerInputId;
+
     if (showKeyboard) {
       _imeConnection!.show();
     }
@@ -94,10 +141,10 @@ class SuperIme with ChangeNotifier {
       return;
     }
 
-    superImeLog.info("Closing IME connection (owner: '$ownerInputId')");
-    print("Closing IME connection (owner: '$ownerInputId')");
+    _log?.onImeConnectionClosed(ownerInputId);
     _imeConnection?.close();
     _imeConnection = null;
+    _connectionOwner = null;
     _attachedClient = null;
 
     notifyListeners();
@@ -126,7 +173,7 @@ class SuperIme with ChangeNotifier {
       return;
     }
 
-    superImeLog.info("Giving IME ownership to new owner (owner: '$newOwnerInputId')");
+    _log?.onOwnershipClaimed(newOwner: newOwnerInputId, previousOwner: _owner);
     _owner = newOwnerInputId;
 
     notifyListeners();
@@ -148,9 +195,8 @@ class SuperIme with ChangeNotifier {
       return;
     }
 
-    superImeLog.info("Releasing IME ownership (owner: '$ownerInputId')");
+    _log?.onOwnershipReleased(ownerInputId, willCloseConnection: clearConnectionOnRelease);
     if (clearConnectionOnRelease) {
-      superImeLog.info("Closing connection when releasing IME ownership (owner: '$ownerInputId')");
       clearConnection(ownerInputId);
     }
     _owner = null;
@@ -238,4 +284,71 @@ class SuperImeInputId {
 
   @override
   int get hashCode => role.hashCode ^ instance.hashCode;
+}
+
+/// Logger for [SuperIme] events, which can be used to print events to console, or
+/// to forward those events to logging backend systems.
+class SuperImeLog {
+  /// The [newOwner] explicitly requested ownership, taking it from [previousOwner].
+  void onOwnershipClaimed({
+    required SuperImeInputId newOwner,
+    required SuperImeInputId? previousOwner,
+  }) {
+    superImeLog.info("Giving IME ownership to new owner: '$newOwner', from previous owner: $previousOwner");
+  }
+
+  /// The [previousOwner] explicitly requested to give up ownership.
+  void onOwnershipReleased(
+    SuperImeInputId previousOwner, {
+    required bool willCloseConnection,
+  }) {
+    superImeLog.info("Releasing IME ownership from: '$previousOwner'");
+    superImeLog.info(" - SuperIme will close the connection after releasing ownership");
+  }
+
+  /// A new IME connection was opened with the OS, via `TextInput.attach()`, and
+  /// this happened either without any previous connection existing, or this happened
+  /// after another connection was explicitly closed.
+  ///
+  /// This event is distinct from [onImeConnectionSwitchedBetweenInstances], even though
+  /// both of these events involve a connection being opened.
+  void onNewImeConnectionOpened(SuperImeInputId owner) {
+    superImeLog.info("Opening a new IME connection from a closed connection. Owner: $owner");
+  }
+
+  /// The IME was owned and open, then a new owner from a completely different editor
+  /// took control, and replaced the previous connection with its own, new connection.
+  void onImeConnectionSwitchedBetweenRoles({
+    required SuperImeInputId previousOwner,
+    required SuperImeInputId newOwner,
+  }) {
+    superImeLog.info(
+      "Replacing IME connection, because owner changed roles.\n - Previous: $previousOwner\n - New: $newOwner",
+    );
+  }
+
+  /// The IME was owned and open, then a new owner took over with the same role, but
+  /// different instance, so the connection was closed for the first instance, and
+  /// immediately re-opened for the second instance.
+  ///
+  /// This happens when one input widget (like `SuperEditor`) has its widget tree
+  /// re-created, which throws out the previous `State` and creates a new `State`.
+  /// When this happens, the user expects the connection and keyboard to remain
+  /// exactly as-is, but internally, because the `State` object was replaced, there's
+  /// a new IME client instance. The only way to switch out the IME client is to
+  /// close the current connection, and then open a new one, with the new client.
+  ///
+  /// This event is emitted when this close/open series happens.
+  void onImeConnectionSwitchedBetweenInstances({
+    required SuperImeInputId previousOwner,
+    required SuperImeInputId newOwner,
+  }) {
+    superImeLog.info(
+      "Replacing IME connection, because owner changed instances.\n - Previous: $previousOwner\n - New: $newOwner",
+    );
+  }
+
+  void onImeConnectionClosed(SuperImeInputId ownerBeforeClose) {
+    superImeLog.info("Closing IME connection (owner: '$ownerBeforeClose')");
+  }
 }

--- a/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
+++ b/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
@@ -334,8 +334,12 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
 
     if (widget.imeOverrides != oldWidget.imeOverrides) {
       if (true == oldWidget.imeOverrides?.isCurrentClient(_documentImeClient)) {
+        // Remove ourselves as the IME client from the old IME decorator, but ONLY
+        // if we're still registered as the client (some other client may have
+        // installed itself, which means it's none of our business).
         oldWidget.imeOverrides?.client = null;
       }
+
       _configureImeClientDecorators();
     }
   }
@@ -403,11 +407,7 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
   }
 
   void _onSharedImeChange() {
-    print(
-      "supereditor_ime_interactor.dart - _onSharedImeChange, this: $_myImeId, new owner: ${SuperIme.instance.owner}",
-    );
     if (!SuperIme.instance.isOwner(_myImeId)) {
-      print(" - it's not ours");
       // We don't own the IME. Update our accounting.
       _ownedImeConnection.value = null;
 
@@ -422,7 +422,6 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
     }
 
     if (!SuperIme.instance.isInputAttachedToOS(_myImeId)) {
-      print(" - we own it, but the connection to the OS has closed");
       // We own the IME, but our connection to the OS was closed.
       _documentImeConnection.value = null;
       widget.imeOverrides?.client = null;
@@ -430,8 +429,6 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
       return;
     }
 
-    print(" - we own it. Grabbing connection and configuring ourselves.");
-    print(" - our IME client: ${_imeClient.hashCode}");
     _ownedImeConnection.value = SuperIme.instance.getImeConnectionForOwner(_myImeId);
     _configureImeClientDecorators();
     _documentImeConnection.value = _documentImeClient;
@@ -440,8 +437,6 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
       // the IME was owned by a different client that had an open connection. Close that connection
       // and open our own. If we don't do this, the IME connection will continue talking to
       // the previous editor's client.
-      print(
-          " - re-opening IME connection because a connection is open, but it's not using this instance of Super Editor's IME client.");
       SuperIme.instance.openConnection(
         _myImeId,
         _imeClient,

--- a/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
+++ b/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
@@ -429,11 +429,15 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
       return;
     }
 
+    // We own the IME, and a connection is open. Update our connection accounting,
+    // and make sure the open connection is configured for us, and not some previous
+    // client.
     _ownedImeConnection.value = SuperIme.instance.getImeConnectionForOwner(_myImeId);
     _configureImeClientDecorators();
     _documentImeConnection.value = _documentImeClient;
+
     if (SuperIme.instance.isInputAttachedToOS(_myImeId) && SuperIme.instance.attachedClient != _imeClient) {
-      // The IME is attached to the OS, but it's not using our client. This probably because
+      // The IME is attached to the OS, but it's not using our client. This is probably because
       // the IME was owned by a different client that had an open connection. Close that connection
       // and open our own. If we don't do this, the IME connection will continue talking to
       // the previous editor's client.

--- a/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
+++ b/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
@@ -307,6 +307,13 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
 
       if (didOwnIme) {
         // Re-take IME ownership.
+        //
+        // Note: In general when taking ownership, we need to be mindful of an IME
+        // connection that might already be open, and would therefore be tied to an
+        // existing IME client. In this case, because we were the previous owner, and
+        // the new owner, if an IME connection is open, it should be our IME client
+        // that's bound to it. So we don't need to open a new IME connection just
+        // because we took ownership.
         SuperIme.instance.takeOwnership(_myImeId);
       }
     }
@@ -326,7 +333,9 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
     }
 
     if (widget.imeOverrides != oldWidget.imeOverrides) {
-      oldWidget.imeOverrides?.client = null;
+      if (true == oldWidget.imeOverrides?.isCurrentClient(_documentImeClient)) {
+        oldWidget.imeOverrides?.client = null;
+      }
       _configureImeClientDecorators();
     }
   }
@@ -394,17 +403,26 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
   }
 
   void _onSharedImeChange() {
+    print(
+      "supereditor_ime_interactor.dart - _onSharedImeChange, this: $_myImeId, new owner: ${SuperIme.instance.owner}",
+    );
     if (!SuperIme.instance.isOwner(_myImeId)) {
+      print(" - it's not ours");
       // We don't own the IME. Update our accounting.
       _ownedImeConnection.value = null;
 
       _documentImeConnection.value = null;
-      widget.imeOverrides?.client = null;
+      if (true == widget.imeOverrides?.isCurrentClient(_documentImeClient)) {
+        // We're still the IME overrides client. Remove ourselves because we no
+        // longer own the IME.
+        widget.imeOverrides?.client = null;
+      }
       widget.isImeConnected?.value = false;
       return;
     }
 
     if (!SuperIme.instance.isInputAttachedToOS(_myImeId)) {
+      print(" - we own it, but the connection to the OS has closed");
       // We own the IME, but our connection to the OS was closed.
       _documentImeConnection.value = null;
       widget.imeOverrides?.client = null;
@@ -412,9 +430,32 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
       return;
     }
 
+    print(" - we own it. Grabbing connection and configuring ourselves.");
+    print(" - our IME client: ${_imeClient.hashCode}");
     _ownedImeConnection.value = SuperIme.instance.getImeConnectionForOwner(_myImeId);
     _configureImeClientDecorators();
     _documentImeConnection.value = _documentImeClient;
+    if (SuperIme.instance.isInputAttachedToOS(_myImeId) && SuperIme.instance.attachedClient != _imeClient) {
+      // The IME is attached to the OS, but it's not using our client. This probably because
+      // the IME was owned by a different client that had an open connection. Close that connection
+      // and open our own. If we don't do this, the IME connection will continue talking to
+      // the previous editor's client.
+      print(
+          " - re-opening IME connection because a connection is open, but it's not using this instance of Super Editor's IME client.");
+      SuperIme.instance.openConnection(
+        _myImeId,
+        _imeClient,
+        widget.imeConfiguration.toTextInputConfiguration(viewId: View.of(context).viewId),
+        // To keep the keyboard up when transitioning from an old SuperEditor instance
+        // to a new SuperEditor instance, we must explicitly tell it to `show()` after
+        // opening the new connection.
+        //
+        // I'm not entirely sure that we always want this to be `true`, but at the time of
+        // writing this, I don't know of a situation where we wouldn't. If we discover one,
+        // re-evaluate this.
+        showKeyboard: true,
+      );
+    }
 
     _reportVisualInformationToIme();
 


### PR DESCRIPTION
[Super Editor][IME][Bug]: Fixed zombie IME client when switching from one SuperEditor instance to a replacement SuperEditor instance (Resolve #2965)

From the issue ticket:
1. SuperEditor initializes
2. SuperEditor creates its IME client and connects it to the OS via SharedIme
3. The ancestor tree gets invalidated (a parent calling setState())
4. SuperEditor 2 initializes
5. SuperEditor 2 claims ownership over IME (but no connection is created because we're the same "role" and there's already a connection)
6. SuperEditor 1 disposes (no impact on SharedIme because this instance is no longer the owner)

**Problem:** The existing IME connection, which survives across the widget instance change, it bound to the IME client for SuperEditor 1, which is different from the IME client for SuperEditor 2. As a result, IME input keeps flowing to the defunct IME client, which belongs to the now disposed SuperEditor 1. This means the keyboard stays up, the user is typing, suggested input continues to display at the top of the keyboard, and yet nothing changes in the editor.

This problem is the result of me originally thinking that we could re-use the connection. I missed the fact that when claiming the SharedIme, and passing the client, we need to create an entirely new connection for the client, even if a connection is already open. There is no option in Flutter's API to replace one client with another, within the same connection.

One wrinkle to also remember here is that, I believe, when we open a new connection, we must tell the keyboard to show() if we want it to stay up. By default, if we don't do that, creating a new connection causes the keyboard to close.