### PR TITLE
[Super Editor][IME][Bug] - Fix: Tag deletion error when using Microsoft SwiftKey keyboard (Resolves #2975)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -92,6 +92,17 @@ class TextDeltasDocumentEditor {
       editorImeLog.info("---------------------------------------------------");
     }
 
+    // End the editor transaction for all deltas in this call.
+    editor.endTransaction();
+
+    // Re-serialize document after end of transaction because reactions may have
+    // run and further changed it.
+    _serializedDoc = DocumentImeSerializer(
+      document,
+      selection.value!,
+      composingRegion.value,
+    );
+
     // Update the editor's IME composing region based on the composing region
     // for the last delta. If the version of our document serialized hidden
     // characters in the IME, adjust for those hidden characters before setting
@@ -109,9 +120,6 @@ class TextDeltasDocumentEditor {
       ]);
     }
     editorImeLog.fine("Document composing region: ${composingRegion.value}");
-
-    // End the editor transaction for all deltas in this call.
-    editor.endTransaction();
 
     _nextImeValue = null;
   }


### PR DESCRIPTION
[Super Editor][IME][Bug] - Fix: Tag deletion error when using Microsoft SwiftKey keyboard (Resolves #2975)

The behavior coming from the keyboard that caused us a problem was that when deleting a character in a tag, the SwiftKey keyboard would report the deletion along with a composing region that included the upstream word. The tag reaction would then delete the whole tag, making the composing region invalid. We would then send an update back to the IME with the entire tag deleted, and a composing region that exceeded the length of the text, which resulted in an IME error.

The root cause was two related things:
 1. We weren't ending the editor transaction before setting the composing region. In theory, it makes sense to change the composing region in the same transaction, but reactions only run after a transaction, which means the tag removal was running AFTER we updated the composing region.
 2. We weren't re-serializing the document after applying the deltas, but before checking the composing region. Because of this, when we checked the composing region's offsets, we were comparing to the text before the deletion, at which point the composing region was valid. Instead, we need to re-serialize the document, which includes the removal of the tag, and THEN check the composing region offsets. By doing that, we see that the composing region is invalid, and we null it out.

This nuanced composing region management seems like a mess. It would be nice if there were a more holistic way to deal with it, but I'm not sure what it is. There are cases where we definitely want to keep the composing region, e.g., when composing a compound character. So we can't just throw it out all the time.