### PR TITLE
[Super Editor][IME][Android][Samsung][GBoard]: Fix error when Samsung sends deltas after newline key, fix GBoard removes trailing space in empty paragraph when inserting newline (Resolves #2979)(Resolves #2981)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/core/document.dart';
@@ -6,13 +7,12 @@ import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/core/editor.dart';
 import 'package:super_editor/src/default_editor/common_editor_operations.dart';
+import 'package:super_editor/src/default_editor/document_ime/document_serialization.dart';
 import 'package:super_editor/src/default_editor/multi_node_editing.dart';
 import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
 import 'package:super_editor/src/default_editor/text.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/platforms/platform.dart';
-
-import 'document_serialization.dart';
 
 /// Applies software keyboard text deltas to a document.
 class TextDeltasDocumentEditor {
@@ -25,6 +25,7 @@ class TextDeltasDocumentEditor {
     required this.composingRegion,
     required this.commonOps,
     required this.onPerformAction,
+    this.log,
   });
 
   final Editor editor;
@@ -38,14 +39,25 @@ class TextDeltasDocumentEditor {
   /// Handles newlines that are inserted as text, e.g., "\n" in deltas.
   final void Function(TextInputAction) onPerformAction;
 
+  /// A logger that is notified of events specifically to [TextDeltasDocumentEditor],
+  /// which lets apps report those specific events to their own issue tracker.
+  final TextDeltasDocumentEditorLog? log;
+
   late DocumentImeSerializer _serializedDoc;
   late TextEditingValue _previousImeValue;
   TextEditingValue? _nextImeValue;
 
   /// Applies the given [textEditingDeltas] to the [Document].
   void applyDeltas(List<TextEditingDelta> textEditingDeltas) {
-    editorImeLog.info("Applying ${textEditingDeltas.length} IME deltas to document");
+    // Check for GBoard aggressive trailing space deletion, which prevents
+    // inserting a paragraph after an empty paragraph.
+    final isGBoardNewlineSpaceRemoval = _isGBoardTrailingSpaceRemoval(textEditingDeltas);
+    if (isGBoardNewlineSpaceRemoval) {
+      log?.onGBoardNewlineTrailingSpaceRemoval(textEditingDeltas);
+      return;
+    }
 
+    editorImeLog.info("Applying ${textEditingDeltas.length} IME deltas to document");
     editorImeDeltasLog.fine("Incoming deltas:");
     for (final delta in textEditingDeltas) {
       editorImeDeltasLog.fine(delta);
@@ -71,29 +83,75 @@ class TextDeltasDocumentEditor {
     // application is considered a single undo-able change.
     editor.startTransaction();
 
-    for (final delta in textEditingDeltas) {
-      editorImeLog.info("---------------------------------------------------");
+    try {
+      for (final delta in textEditingDeltas) {
+        editorImeLog.info("---------------------------------------------------");
 
-      editorImeLog.info("Applying delta: $delta");
+        editorImeLog.info("Applying delta: $delta");
 
-      _nextImeValue = delta.apply(_previousImeValue);
-      if (delta is TextEditingDeltaInsertion) {
-        _applyInsertion(delta);
-      } else if (delta is TextEditingDeltaReplacement) {
-        _applyReplacement(delta);
-      } else if (delta is TextEditingDeltaDeletion) {
-        _applyDeletion(delta);
-      } else if (delta is TextEditingDeltaNonTextUpdate) {
-        _applyNonTextChange(delta);
-      } else {
-        editorImeLog.shout("Unknown IME delta type: ${delta.runtimeType}");
+        _nextImeValue = delta.apply(_previousImeValue);
+        if (delta is TextEditingDeltaInsertion) {
+          _applyInsertion(delta);
+        } else if (delta is TextEditingDeltaReplacement) {
+          _applyReplacement(delta);
+        } else if (delta is TextEditingDeltaDeletion) {
+          _applyDeletion(delta);
+        } else if (delta is TextEditingDeltaNonTextUpdate) {
+          _applyNonTextChange(delta);
+        } else {
+          editorImeLog.shout("Unknown IME delta type: ${delta.runtimeType}");
+        }
+
+        editorImeLog.info("---------------------------------------------------");
       }
-
-      editorImeLog.info("---------------------------------------------------");
+    } on FailedToMapImePositionToDocumentPositionException catch (exception, stacktrace) {
+      // We fail silently on this error due to a Samsung delta ordering issue. When the user
+      // presses `newline` button, we receive 2 events, but in the wrong order. We *should*
+      // receive:
+      //
+      //  1. Text replacement for upstream word auto-correction
+      //  2. `ENTER` key pressed
+      //
+      // But what we get is:
+      //
+      //  1. `ENTER` key pressed
+      //  2. Text replacement for upstream word auto-correction (which is now in previous paragraph)
+      //
+      // The best we can do is stop the delta applications right now, serialize what we've got
+      // and send our current state to the IME to get us back in sync. This might still erase
+      // some changes that the user applied, but hopefully the editor will continue to respond
+      // to future input.
+      //
+      // Note: We added this specifically to get around a Samsung bug (https://github.com/Flutter-Bounty-Hunters/super_editor/issues/2979)
+      // but this error could appear for any number of reasons, and so there may be situations in which
+      // we shouldn't swallow this error. If we find those, update this logic accordingly.
+      log?.onFailedToMapImePositionToDocumentPosition(exception, stacktrace);
+    } on FailedToMapDocumentPositionToImePositionException catch (exception, stacktrace) {
+      // We added this catch at the same time as `FailedToMapImePositionToDocumentPositionException`.
+      // The other catch was added for a specific Samsung bug. That bug doesn't trigger this
+      // exception, nor have we seen this exception elsewhere, but I thought that if we're going
+      // to swallow and short-circuit deltas when the mapping fails one direction, then we should
+      // do the same thing in the other direction.
+      //
+      // The hope is that if we ever fail to map from the document to the IME, we short-circuit
+      // here and immediately send our current document to the IME, thus returning the IME to a
+      // valid state for future editing. Similar to the other error that we swallow, by swallowing
+      // this one, there might be missed content changes from the user's perspective. However, it's
+      // more important that we keep a working editor than that we avoid the appearance of buggy input.
+      log?.onFailedToMapDocumentPositionToImePosition(exception, stacktrace);
+    } catch (exception, stacktrace) {
+      // This is an unknown error, and therefore it would be dangerous to swallow it. Rethrow it
+      // so that apps can catch this issue, and also maybe report it to their issue tracker.
+      log?.onFailedToApplyDeltasForUnknownReason(exception, stacktrace);
+      rethrow;
+    } finally {
+      // We must always end the transaction, even if an error occurred. Otherwise, we'll get
+      // stuck with an open transaction and the editor will never stabilize.
+      //
+      // End the editor transaction for all deltas in this call.
+      editorImeLog.info("Done with deltas. Ending transaction.");
+      editor.endTransaction();
     }
-
-    // End the editor transaction for all deltas in this call.
-    editor.endTransaction();
 
     // Re-serialize document after end of transaction because reactions may have
     // run and further changed it.
@@ -122,6 +180,64 @@ class TextDeltasDocumentEditor {
     editorImeLog.fine("Document composing region: ${composingRegion.value}");
 
     _nextImeValue = null;
+  }
+
+  /// Returns `true` if we believe the given batch of [deltas] represent a GBoard
+  /// automatically deleting the trailing space of an empty paragraph when the user
+  /// presses "newline".
+  ///
+  /// ## Explanation of Problem
+  /// We encode empty paragraphs as ". ". We do this for two reasons:
+  ///
+  ///  1. We need some non-empty content so we can detect a "backspace" at the beginning
+  ///     of a paragraph.
+  ///  2. We need to trick the IME into giving us auto-capitalization, which happens
+  ///     naturally after the end of a sentence, hence the ". ".
+  ///
+  /// Our hidden ". " encoding works fine almost everywhere, and it almost call cases.
+  /// The except is when the user tries press "newline" on a GBoard. the GBoard interprets
+  /// this situation as the user going to a new line while leaving a dangling space after
+  /// the end of a sentence, and therefore the GBoard tries to remove that space.
+  ///
+  /// Example of deltas in a real interaction:
+  ///
+  /// ```
+  /// TextEditingDeltaNonTextUpdate - old text: '. ', offset: 2
+  /// TextEditingDeltaNonTextUpdate - old text: '. ', offset: 2
+  /// TextEditingDeltaNonTextUpdate - old text: '. ', offset: 2
+  /// TextEditingDeltaNonTextUpdate - old text: '. ', offset: 2
+  /// TextEditingDeltaNonTextUpdate - old text: '. ', offset: 2
+  /// TextEditingDeltaNonTextUpdate - old text: '. ', offset: 2
+  /// TextEditingDeltaDeletion - old text: '. ', offset: 1
+  /// ```
+  ///
+  /// We don't know for sure why there are so many repeat non-text updates. This might be
+  /// a consequence of how the GBoard IME reporting implementation works with Flutter's
+  /// batching system.
+  bool _isGBoardTrailingSpaceRemoval(List<TextEditingDelta> deltas) {
+    if (deltas.length < 2) {
+      // We expect at least 2 deltas when the GBoard tries to remove a trailing space.
+      return false;
+    }
+
+    final lastDelta = deltas.last;
+    if (lastDelta is! TextEditingDeltaDeletion) {
+      // We expect the last delta to be a trailing space deletion, but this one isn't
+      // a deletion at all.
+      return false;
+    }
+
+    final deltasBeforeDeletion = deltas.sublist(0, deltas.length - 1);
+    if (deltasBeforeDeletion.firstWhereOrNull((delta) => delta is! TextEditingDeltaNonTextUpdate) != null) {
+      // We expect all deltas before the deletion to be repeated composing region changes.
+      // But in this case, there are some mutating deltas (insert, replace, delete) before the
+      // final deletion. So this isn't an automatic GBoard space removal in an empty paragraph.
+      return false;
+    }
+
+    // We believe that this situation represents the GBoard auto-deleting the trailing
+    // space in an empty paragraph, because we encode an empty paragraph as ". ".
+    return true;
   }
 
   void _applyInsertion(TextEditingDeltaInsertion delta) {
@@ -261,7 +377,7 @@ class TextDeltasDocumentEditor {
     editorImeLog.fine("OS-side selection - ${delta.selection}");
     editorImeLog.fine("OS-side composing - ${delta.composing}");
 
-    DocumentSelection? docSelection = _calculateNewDocumentSelection(delta);
+    var docSelection = _calculateNewDocumentSelection(delta);
     DocumentRange? docComposingRegion = _calculateNewComposingRegion([delta]);
 
     if (docSelection != null) {
@@ -583,5 +699,59 @@ class TextDeltasDocumentEditor {
     }
 
     return _serializedDoc.imeToDocumentRange(lastDelta.composing);
+  }
+}
+
+abstract class TextDeltasDocumentEditorLog {
+  void onGBoardNewlineTrailingSpaceRemoval(List<TextEditingDelta> textEditingDeltas);
+
+  void onFailedToMapImePositionToDocumentPosition(
+    FailedToMapImePositionToDocumentPositionException exception,
+    StackTrace stacktrace,
+  );
+
+  void onFailedToMapDocumentPositionToImePosition(
+    FailedToMapDocumentPositionToImePositionException exception,
+    StackTrace stacktrace,
+  );
+
+  void onFailedToApplyDeltasForUnknownReason(Object exception, StackTrace stacktrace);
+}
+
+class ConsolePrintTextDeltasDocumentEditorLog implements TextDeltasDocumentEditorLog {
+  @override
+  void onGBoardNewlineTrailingSpaceRemoval(List<TextEditingDelta> textEditingDeltas) {
+    editorImeLog.fine("Detected a GBoard newline trailing space removal. Deltas:");
+    for (final delta in textEditingDeltas) {
+      editorImeLog
+          .fine(" > ${delta.runtimeType} - old text: ${delta.oldText}, selection: ${delta.selection.extentOffset}");
+    }
+  }
+
+  @override
+  void onFailedToMapImePositionToDocumentPosition(
+    FailedToMapImePositionToDocumentPositionException exception,
+    StackTrace stacktrace,
+  ) {
+    editorImeLog.warning("Failed to apply some deltas due to bad IME-to-document mapping.");
+    editorImeLog.warning(exception);
+    editorImeLog.warning("$stacktrace");
+  }
+
+  @override
+  void onFailedToMapDocumentPositionToImePosition(
+    FailedToMapDocumentPositionToImePositionException exception,
+    StackTrace stacktrace,
+  ) {
+    editorImeLog.warning("Failed to apply some deltas due to bad document-to-IME mapping.");
+    editorImeLog.warning(exception);
+    editorImeLog.warning("$stacktrace");
+  }
+
+  @override
+  void onFailedToApplyDeltasForUnknownReason(Object exception, StackTrace stacktrace) {
+    editorImeLog.shout("Unknown exception while applying deltas:");
+    editorImeLog.shout(exception);
+    editorImeLog.shout(stacktrace);
   }
 }

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -728,6 +728,8 @@ abstract class TextDeltasDocumentEditorLog {
 }
 
 class ConsolePrintTextDeltasDocumentEditorLog implements TextDeltasDocumentEditorLog {
+  const ConsolePrintTextDeltasDocumentEditorLog();
+
   @override
   void onGBoardNewlineTrailingSpaceRemoval(List<TextEditingDelta> textEditingDeltas) {
     editorImeLog.fine("Detected a GBoard newline trailing space removal. Deltas:");

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -235,6 +235,15 @@ class TextDeltasDocumentEditor {
       return false;
     }
 
+    for (final nonTextDelta in deltasBeforeDeletion) {
+      // We expect the reported text in every non-text delta to be an empty paragraph encoding.
+      if (nonTextDelta.oldText != ". ") {
+        // This delta has a text value that isn't an empty paragraph, so this looks like
+        // some other kind of delta batch.
+        return false;
+      }
+    }
+
     // We believe that this situation represents the GBoard auto-deleting the trailing
     // space in an empty paragraph, because we encode an empty paragraph as ". ".
     return true;

--- a/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
@@ -37,8 +37,13 @@ class DocumentImeSerializer {
   final Document _doc;
   DocumentSelection selection;
   DocumentRange? composingRegion;
+
+  /// Maps sub-strings of the IME value to node IDs.
   final imeRangesToDocTextNodes = <TextRange, String>{};
+
+  /// Maps node IDs to sub-strings of the IME value.
   final docTextNodesToImeRanges = <String, TextRange>{};
+
   final selectedNodes = <DocumentNode>[];
   late String imeText;
   final PrependedCharacterPolicy _prependedCharacterPolicy;
@@ -306,8 +311,11 @@ class DocumentImeSerializer {
       editorImeLog.shout("    ^ node content: '${(_doc.getNodeById(entry.value) as TextNode).text.toPlainText()}'");
     }
     editorImeLog.shout("-----------------------------------------------------------");
-    throw Exception(
-        "Couldn't map an IME position to a document position. \nTextEditingValue: '$imeText'\nIME position: $imePosition");
+    throw FailedToMapImePositionToDocumentPositionException(
+      imeText: imeText,
+      imePosition: imePosition,
+      imeRangesToDocumentRanges: Map.from(imeRangesToDocTextNodes),
+    );
   }
 
   TextSelection documentToImeSelection(DocumentSelection docSelection) {
@@ -371,7 +379,11 @@ class DocumentImeSerializer {
       return TextPosition(offset: imeRange.start + (docPosition.nodePosition as TextNodePosition).offset);
     }
 
-    throw Exception("Super Editor doesn't know how to convert a $nodePosition into an IME-compatible selection");
+    throw FailedToMapDocumentPositionToImePositionException(
+      document: _doc,
+      selection: selection,
+      documentNodesToImeRanges: docTextNodesToImeRanges,
+    );
   }
 
   TextEditingValue toTextEditingValue() {
@@ -394,4 +406,66 @@ enum PrependedCharacterPolicy {
   automatic,
   include,
   exclude,
+}
+
+class FailedToMapImePositionToDocumentPositionException implements Exception {
+  const FailedToMapImePositionToDocumentPositionException({
+    required this.imeText,
+    required this.imePosition,
+    required this.imeRangesToDocumentRanges,
+  });
+
+  final String imeText;
+  final TextPosition imePosition;
+  final Map<TextRange, String> imeRangesToDocumentRanges;
+
+  @override
+  String toString() {
+    final buffer = StringBuffer("Couldn't map an IME position to a document position.\n")
+      ..writeln(" • IME text: '$imeText'")
+      ..writeln(" • IME position: $imePosition");
+
+    buffer.writeln(" • IME to Doc Ranges:");
+    for (final entry in imeRangesToDocumentRanges.entries) {
+      buffer.writeln("    > IME range: ${entry.key} -> Node: '${entry.value}'");
+    }
+
+    return buffer.toString();
+  }
+}
+
+class FailedToMapDocumentPositionToImePositionException implements Exception {
+  const FailedToMapDocumentPositionToImePositionException({
+    required this.document,
+    required this.selection,
+    required this.documentNodesToImeRanges,
+  });
+
+  final Document document;
+  final DocumentSelection selection;
+  final Map<String, TextRange> documentNodesToImeRanges;
+
+  @override
+  String toString() {
+    final buffer = StringBuffer("Couldn't map a document position to an IME position.\n");
+
+    buffer.writeln(" • Document:");
+    for (final node in document) {
+      buffer.writeln("    > node ID: ${node.id}, type: ${node.runtimeType}");
+      if (node is TextNode) {
+        buffer.writeln("      - text in node: '${node.text.toPlainText()}'");
+      }
+    }
+
+    buffer.writeln(" • Document selection:");
+    buffer.writeln("    > base: ${selection.base}");
+    buffer.writeln("    > extent: ${selection.extent}");
+
+    buffer.writeln(" • IME to Doc Ranges:");
+    for (final entry in documentNodesToImeRanges.entries) {
+      buffer.writeln("    > Node: ${entry.key} -> IME range: '${entry.value}'");
+    }
+
+    return buffer.toString();
+  }
 }

--- a/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
+++ b/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
@@ -51,6 +51,7 @@ class SuperEditorImeInteractor extends StatefulWidget {
     this.hardwareKeyboardActions = const [],
     required this.selectorHandlers,
     this.floatingCursorController,
+    this.log,
     required this.child,
   }) : super(key: key);
 
@@ -147,6 +148,10 @@ class SuperEditorImeInteractor extends StatefulWidget {
   /// The IME reports selectors as unique `String`s, therefore selector handlers are
   /// defined as a mapping from selector names to handler functions.
   final Map<String, SuperEditorSelectorHandler> selectorHandlers;
+
+  /// A logger that is notified of events specifically to [TextDeltasDocumentEditor],
+  /// which lets apps report those specific events to their own issue tracker.
+  final TextDeltasDocumentEditorLog? log;
 
   final Widget child;
 
@@ -399,6 +404,7 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
         composerPreferences: widget.editContext.composer.preferences,
         composingRegion: widget.editContext.composer.composingRegion,
         commonOps: widget.editContext.commonOps,
+        log: widget.log,
         onPerformAction: (action) => _imeClient.performAction(action),
       ),
       imeConnection: _ownedImeConnection,

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -28,6 +28,7 @@ import 'package:super_editor/src/infrastructure/documents/document_scaffold.dart
 import 'package:super_editor/src/infrastructure/documents/document_scroller.dart';
 import 'package:super_editor/src/infrastructure/documents/selection_leader_document_layer.dart';
 import 'package:super_editor/src/infrastructure/flutter/build_context.dart';
+import 'package:super_editor/src/infrastructure/keyboard.dart';
 import 'package:super_editor/src/infrastructure/platforms/android/toolbar.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/toolbar.dart';
 import 'package:super_editor/src/infrastructure/platforms/mac/mac_ime.dart';

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -142,6 +142,7 @@ class SuperEditor extends StatefulWidget {
     this.plugins = const {},
     this.debugPaint = const DebugPaintConfig(),
     this.shrinkWrap = false,
+    this.log = const SuperEditorPrintLog(),
   })  : stylesheet = stylesheet ?? defaultStylesheet,
         selectionStyles = selectionStyle ?? defaultSelectionStyle,
         componentBuilders = [
@@ -382,6 +383,14 @@ class SuperEditor extends StatefulWidget {
   /// Whether the scroll view used by the editor should shrink-wrap its contents.
   /// Only used when editor is not inside an scrollable.
   final bool shrinkWrap;
+
+  /// A log that reports specific errors and exceptional events that occur while
+  /// running a [SuperEditor].
+  ///
+  /// This log was introduced to create a place to report errors to apps that those
+  /// apps might want to send to their own issue tracker to gain visibility into why
+  /// issues are happening in their editor.
+  final SuperEditorPrintLog? log;
 
   @override
   SuperEditorState createState() => SuperEditorState();
@@ -850,6 +859,7 @@ class SuperEditorState extends State<SuperEditor> {
           ],
           selectorHandlers: widget.selectorHandlers ?? defaultEditorSelectorHandlers,
           isImeConnected: _isImeConnected,
+          log: widget.log?.imeDeltas,
           child: child,
         );
     }
@@ -1844,3 +1854,16 @@ TextStyle defaultStyleBuilder(Set<Attribution> attributions) {
 const defaultSelectionStyle = SelectionStyles(
   selectionColor: Color(0xFFACCEF7),
 );
+
+/// A log that reports specific important errors and exceptional situations that
+/// happen when running a [SuperEditor].
+abstract class SuperEditorLog {
+  TextDeltasDocumentEditorLog get imeDeltas;
+}
+
+class SuperEditorPrintLog implements SuperEditorLog {
+  const SuperEditorPrintLog() : imeDeltas = const ConsolePrintTextDeltasDocumentEditorLog();
+
+  @override
+  final ConsolePrintTextDeltasDocumentEditorLog imeDeltas;
+}

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -28,7 +28,6 @@ import 'package:super_editor/src/infrastructure/documents/document_scaffold.dart
 import 'package:super_editor/src/infrastructure/documents/document_scroller.dart';
 import 'package:super_editor/src/infrastructure/documents/selection_leader_document_layer.dart';
 import 'package:super_editor/src/infrastructure/flutter/build_context.dart';
-import 'package:super_editor/src/infrastructure/keyboard.dart';
 import 'package:super_editor/src/infrastructure/platforms/android/toolbar.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/toolbar.dart';
 import 'package:super_editor/src/infrastructure/platforms/mac/mac_ime.dart';

--- a/super_editor/test/super_editor/supereditor_input_ime_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_ime_test.dart
@@ -670,6 +670,60 @@ Paragraph two
       });
     });
 
+    group('on Samsung', () {
+      testWidgetsOnAndroid('handles out of order newline followed by delta suggestion application', (tester) async {
+        await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        // Place the caret at the start of the paragraph.
+        await tester.placeCaretInParagraph('1', 0);
+
+        // Start typing the word "Anonymous" with typos.
+        await tester.typeImeText('Anonimoi');
+
+        // Simulate the user pressing "newline", which on Samsung results in reporting
+        // the ENTER hardware key, followed by the suggestion deltas. Notice that these
+        // two events are in the wrong order!
+        await tester.pressEnter();
+
+        await tester.ime.sendDeltas(const [
+          TextEditingDeltaNonTextUpdate(
+            oldText: '. Anonimoi',
+            selection: TextSelection.collapsed(
+              offset: 10,
+              affinity: TextAffinity.downstream,
+            ),
+            composing: TextRange(start: 2, end: 10),
+          ),
+          TextEditingDeltaNonTextUpdate(
+            oldText: '. Anonimoi',
+            selection: TextSelection.collapsed(
+              offset: 10,
+              affinity: TextAffinity.downstream,
+            ),
+            composing: TextRange(start: 2, end: 10),
+          ),
+          TextEditingDeltaReplacement(
+            oldText: '. Anonimoi',
+            replacementText: 'Anonymous',
+            replacedRange: TextRange(start: 2, end: 10),
+            selection: TextSelection.collapsed(offset: 11, affinity: TextAffinity.downstream),
+            composing: TextRange(start: -1, end: -1),
+          ),
+        ], getter: imeClientGetter);
+
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.length, 2);
+        // Note: We expect the mis-spelled word to remain because we couldn't apply
+        //       the suggestion due to receiving events in the wrong order.
+        expect((document.first as TextNode).text.toPlainText(), 'Anonimoi');
+        expect((document.last as TextNode).text.toPlainText(), '');
+      });
+    });
+
     group('GBoard >', () {
       testWidgetsOnAndroid('can insert newline into empty paragraph', (tester) async {
         // Verifies fix for GBoard empty paragraph newline bug:

--- a/super_editor/test/super_editor/supereditor_input_ime_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_ime_test.dart
@@ -670,6 +670,73 @@ Paragraph two
       });
     });
 
+    group('GBoard >', () {
+      testWidgetsOnAndroid('can insert newline into empty paragraph', (tester) async {
+        // Verifies fix for GBoard empty paragraph newline bug:
+        // https://github.com/Flutter-Bounty-Hunters/super_editor/issues/2981
+
+        await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        // Place the caret at the start of the paragraph.
+        await tester.placeCaretInParagraph('1', 0);
+
+        // Simulate press of the newline button.
+        //
+        // On GBoard this is reported as the ENTER key, followed by corrective dangling
+        // space removal deltas. Technically those deltas are sent out of order. This is
+        // because the empty paragraph is encoded as ". ".
+        await tester.pressEnter();
+
+        await tester.ime.sendDeltas(const [
+          // GBoard seems to send a bunch of identical non-text updates.
+          TextEditingDeltaNonTextUpdate(
+            oldText: '. ',
+            selection: TextSelection.collapsed(offset: 2),
+            composing: TextRange.empty,
+          ),
+          TextEditingDeltaNonTextUpdate(
+            oldText: '. ',
+            selection: TextSelection.collapsed(offset: 2),
+            composing: TextRange.empty,
+          ),
+          TextEditingDeltaNonTextUpdate(
+            oldText: '. ',
+            selection: TextSelection.collapsed(offset: 2),
+            composing: TextRange.empty,
+          ),
+          TextEditingDeltaNonTextUpdate(
+            oldText: '. ',
+            selection: TextSelection.collapsed(offset: 2),
+            composing: TextRange.empty,
+          ),
+          // After the non-text updates, there's a deletion delta that tries to remove the space.
+          TextEditingDeltaDeletion(
+            oldText: '. ',
+            deletedRange: TextRange(start: 1, end: 2),
+            selection: TextSelection.collapsed(
+              offset: 1,
+              affinity: TextAffinity.downstream,
+            ),
+            composing: TextRange(start: -1, end: -1),
+          ),
+        ], getter: imeClientGetter);
+
+        final document = SuperEditorInspector.findDocument();
+        expect(document, isNotNull);
+        expect(document!.length, 2);
+
+        expect(document.first, isA<ParagraphNode>());
+        expect((document.first as TextNode).text.toPlainText(), "");
+
+        expect(document.last, isA<ParagraphNode>());
+        expect((document.last as TextNode).text.toPlainText(), "");
+      });
+    });
+
     group('on iPhone 11 (iOS 13.7) with chinese keyboard', () {
       testWidgetsOnIos('applies keyboard suggestions', (tester) async {
         // Holds the composing region that we sent to the IME.


### PR DESCRIPTION
[Super Editor][IME][Android][Samsung][GBoard]: Fix error when Samsung sends deltas after newline key, fix GBoard removes trailing space in empty paragraph when inserting newline (Resolves #2979)(Resolves #2981)

Issues are thoroughly described in their original tickets:
 * https://github.com/Flutter-Bounty-Hunters/super_editor/issues/2979
 * https://github.com/Flutter-Bounty-Hunters/super_editor/issues/2981

I also added a long-lived write-up to catalog weird issues we find with various platforms and keyboards: https://github.com/Flutter-Bounty-Hunters/super_editor/wiki/IME-Platform-Bugs-(Samsung,-SwiftKey-keyboard,-etc)