### PR TITLE
[Super Editor][iOS][IME] - Fix: Can't backspace empty text nodes on iOS (Resolves #2989)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -215,6 +215,14 @@ class TextDeltasDocumentEditor {
   /// a consequence of how the GBoard IME reporting implementation works with Flutter's
   /// batching system.
   bool _isGBoardTrailingSpaceRemoval(List<TextEditingDelta> deltas) {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      // As far as we know, this issue only happens on GBoards, which only runs
+      // on Android. iOS legitimately uses deltas for almost everything, including
+      // backspace deletion, so we have to very careful if we don't gate this on
+      // the platform.
+      return false;
+    }
+
     if (deltas.length < 2) {
       // We expect at least 2 deltas when the GBoard tries to remove a trailing space.
       return false;
@@ -240,6 +248,14 @@ class TextDeltasDocumentEditor {
       if (nonTextDelta.oldText != ". ") {
         // This delta has a text value that isn't an empty paragraph, so this looks like
         // some other kind of delta batch.
+        return false;
+      }
+
+      if (!nonTextDelta.selection.isCollapsed) {
+        // When iOS backspaces with a delta at the start of a paragraph, it reports
+        // a selection from offset 1 -> 2. Even though we're gating this whole method
+        // on the Android platform, we explicitly exclude this situation as well, just
+        // in case.
         return false;
       }
     }

--- a/super_editor/test/super_editor/supereditor_input_ime_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_ime_test.dart
@@ -422,352 +422,401 @@ void main() {
       });
     });
 
-    // Note: Some Android devices report ENTER and BACKSPACE as hardware keys. Other Android
-    //       devices report "\n" insertion and deletion IME deltas, instead.
-    group('on Xiaomi Redmi tablet (Android 12 SP1A)', () {
-      testWidgetsOnAndroid('applies list of deltas when inserting new lines', (tester) async {
-        // This test simulates inserting a line break in the middle of the text,
-        // followed by a non-text delta placing the selection/composing region on the new line.
-        //
-        // This test runs only on Android, because we only map a \n insertion to a new line on Android.
+    group('Android >', () {
+      // Note: Some Android devices report ENTER and BACKSPACE as hardware keys. Other Android
+      //       devices report "\n" insertion and deletion IME deltas, instead.
+      group('on Xiaomi Redmi tablet (Android 12 SP1A)', () {
+        testWidgetsOnAndroid('applies list of deltas when inserting new lines', (tester) async {
+          // This test simulates inserting a line break in the middle of the text,
+          // followed by a non-text delta placing the selection/composing region on the new line.
+          //
+          // This test runs only on Android, because we only map a \n insertion to a new line on Android.
 
-        await tester //
-            .createDocument()
-            .withSingleEmptyParagraph()
-            .withInputSource(TextInputSource.ime)
-            .pump();
+          await tester //
+              .createDocument()
+              .withSingleEmptyParagraph()
+              .withInputSource(TextInputSource.ime)
+              .pump();
 
-        // Place caret at the start of the document.
-        await tester.placeCaretInParagraph('1', 0);
+          // Place caret at the start of the document.
+          await tester.placeCaretInParagraph('1', 0);
 
-        // Send initial delta.
-        await tester.ime.sendDeltas(
-          const [
-            TextEditingDeltaInsertion(
-              oldText: '. ',
-              textInserted: 'Before the line break new line',
-              insertionOffset: 2,
-              selection: TextSelection.collapsed(offset: 32),
-              composing: TextRange(start: 2, end: 32),
-            )
-          ],
-          getter: imeClientGetter,
-        );
+          // Send initial delta.
+          await tester.ime.sendDeltas(
+            const [
+              TextEditingDeltaInsertion(
+                oldText: '. ',
+                textInserted: 'Before the line break new line',
+                insertionOffset: 2,
+                selection: TextSelection.collapsed(offset: 32),
+                composing: TextRange(start: 2, end: 32),
+              )
+            ],
+            getter: imeClientGetter,
+          );
 
-        // Place the caret at "Before the line break |new line".
-        await tester.placeCaretInParagraph('1', 22);
+          // Place the caret at "Before the line break |new line".
+          await tester.placeCaretInParagraph('1', 22);
 
-        // Add a line break and simulate the OS sending a non-text delta to change the composing region.
-        //
-        // The OS thinks the editing text is "Before the line break \nnew line".
-        //
-        // With the insertion of the line break, the paragraph will be split into two and
-        // our current editing text will be "new line".
-        //
-        // The OS selection is invalid to us, as our editing text changed.
-        await tester.ime.sendDeltas(
-          const [
-            TextEditingDeltaInsertion(
-              oldText: 'Before the line break new line',
-              textInserted: '\n',
-              insertionOffset: 22,
-              selection: TextSelection.collapsed(offset: 23),
-              composing: TextRange(start: -1, end: -1),
+          // Add a line break and simulate the OS sending a non-text delta to change the composing region.
+          //
+          // The OS thinks the editing text is "Before the line break \nnew line".
+          //
+          // With the insertion of the line break, the paragraph will be split into two and
+          // our current editing text will be "new line".
+          //
+          // The OS selection is invalid to us, as our editing text changed.
+          await tester.ime.sendDeltas(
+            const [
+              TextEditingDeltaInsertion(
+                oldText: 'Before the line break new line',
+                textInserted: '\n',
+                insertionOffset: 22,
+                selection: TextSelection.collapsed(offset: 23),
+                composing: TextRange(start: -1, end: -1),
+              ),
+              TextEditingDeltaNonTextUpdate(
+                oldText: 'Before the line break \nnew line',
+                selection: TextSelection.collapsed(offset: 23),
+                composing: TextRange(start: -1, end: -1),
+              ),
+              TextEditingDeltaNonTextUpdate(
+                oldText: 'Before the line break \nnew line',
+                selection: TextSelection.collapsed(offset: 23),
+                composing: TextRange(start: 23, end: 26),
+              ),
+            ],
+            getter: imeClientGetter,
+          );
+
+          final doc = SuperEditorInspector.findDocument()!;
+
+          // Ensure the paragraph was split.
+          expect(
+            (doc.getNodeAt(0)! as ParagraphNode).text.toPlainText(),
+            'Before the line break ',
+          );
+
+          // Ensure the paragraph was split.
+          expect(
+            (doc.getNodeAt(1)! as ParagraphNode).text.toPlainText(),
+            'new line',
+          );
+
+          // Ensure the selection is at the beginning of the second node.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: doc.getNodeAt(1)!.id,
+                nodePosition: const TextNodePosition(offset: 0),
+              ),
             ),
-            TextEditingDeltaNonTextUpdate(
-              oldText: 'Before the line break \nnew line',
-              selection: TextSelection.collapsed(offset: 23),
-              composing: TextRange(start: -1, end: -1),
-            ),
-            TextEditingDeltaNonTextUpdate(
-              oldText: 'Before the line break \nnew line',
-              selection: TextSelection.collapsed(offset: 23),
-              composing: TextRange(start: 23, end: 26),
-            ),
-          ],
-          getter: imeClientGetter,
-        );
+          );
+        });
 
-        final doc = SuperEditorInspector.findDocument()!;
-
-        // Ensure the paragraph was split.
-        expect(
-          (doc.getNodeAt(0)! as ParagraphNode).text.toPlainText(),
-          'Before the line break ',
-        );
-
-        // Ensure the paragraph was split.
-        expect(
-          (doc.getNodeAt(1)! as ParagraphNode).text.toPlainText(),
-          'new line',
-        );
-
-        // Ensure the selection is at the beginning of the second node.
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          DocumentSelection.collapsed(
-            position: DocumentPosition(
-              nodeId: doc.getNodeAt(1)!.id,
-              nodePosition: const TextNodePosition(offset: 0),
-            ),
-          ),
-        );
-      });
-
-      testWidgetsOnAndroid('maintains correct selection after merging paragraphs', (tester) async {
-        await tester //
-            .createDocument()
-            .fromMarkdown('''
+        testWidgetsOnAndroid('maintains correct selection after merging paragraphs', (tester) async {
+          await tester //
+              .createDocument()
+              .fromMarkdown('''
 Paragraph one
 
 Paragraph two
 ''')
-            .withInputSource(TextInputSource.ime)
-            .pump();
+              .withInputSource(TextInputSource.ime)
+              .pump();
 
-        final doc = SuperEditorInspector.findDocument()!;
+          final doc = SuperEditorInspector.findDocument()!;
 
-        // Place caret at the start of the second paragraph.
-        await tester.placeCaretInParagraph(doc.getNodeAt(1)!.id, 0);
+          // Place caret at the start of the second paragraph.
+          await tester.placeCaretInParagraph(doc.getNodeAt(1)!.id, 0);
 
-        // Sends the deletion delta followed by non-text deltas.
-        //
-        // This deletion will cause the two paragraphs to be merged.
-        await tester.ime.sendDeltas(
-          const [
+          // Sends the deletion delta followed by non-text deltas.
+          //
+          // This deletion will cause the two paragraphs to be merged.
+          await tester.ime.sendDeltas(
+            const [
+              TextEditingDeltaNonTextUpdate(
+                oldText: '. Paragraph two',
+                selection: TextSelection.collapsed(offset: 2),
+                composing: TextRange(start: -1, end: -1),
+              ),
+              TextEditingDeltaNonTextUpdate(
+                oldText: 'Paragraph two',
+                selection: TextSelection.collapsed(offset: 0),
+                composing: TextRange(start: 2, end: 11),
+              ),
+              TextEditingDeltaDeletion(
+                oldText: '. Paragraph two',
+                deletedRange: TextRange(start: 1, end: 2),
+                selection: TextSelection.collapsed(offset: 1),
+                composing: TextRange(start: -1, end: -1),
+              ),
+            ],
+            getter: imeClientGetter,
+          );
+
+          // Ensure the paragraph was merged.
+          expect(
+            (doc.getNodeAt(0)! as ParagraphNode).text.toPlainText(),
+            'Paragraph oneParagraph two',
+          );
+
+          // Ensure the selection is at "Paragraph one|Paragraph two".
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: doc.getNodeAt(0)!.id,
+                nodePosition: const TextNodePosition(offset: 13),
+              ),
+            ),
+          );
+        });
+      });
+
+      group('on Samsung M51 (Android 12 SP1A)', () {
+        testWidgetsOnAndroid('applies keyboard suggestions', (tester) async {
+          await tester //
+              .createDocument()
+              .withSingleEmptyParagraph()
+              .withInputSource(TextInputSource.ime)
+              .pump();
+
+          // Place the caret at the start of the paragraph.
+          await tester.placeCaretInParagraph('1', 0);
+
+          // Start typing the word "Anonymous" with typos.
+          await tester.typeImeText('Anonimoi');
+
+          // Simulate the user accepting a suggestion.
+          // The IME replaces the word and inserts a space after it.
+          await tester.ime.sendDeltas(const [
             TextEditingDeltaNonTextUpdate(
-              oldText: '. Paragraph two',
-              selection: TextSelection.collapsed(offset: 2),
+              oldText: '. Anonimoi',
+              selection: TextSelection.collapsed(
+                offset: 10,
+                affinity: TextAffinity.downstream,
+              ),
+              composing: TextRange(start: 2, end: 10),
+            ),
+            TextEditingDeltaReplacement(
+              oldText: '. Anonimoi',
+              replacementText: 'Anonymous',
+              replacedRange: TextRange(start: 2, end: 10),
+              selection: TextSelection.collapsed(offset: 11, affinity: TextAffinity.downstream),
               composing: TextRange(start: -1, end: -1),
             ),
-            TextEditingDeltaNonTextUpdate(
-              oldText: 'Paragraph two',
-              selection: TextSelection.collapsed(offset: 0),
-              composing: TextRange(start: 2, end: 11),
-            ),
+            TextEditingDeltaInsertion(
+              oldText: '. Anonymous',
+              textInserted: ' ',
+              insertionOffset: 11,
+              selection: TextSelection.collapsed(
+                offset: 12,
+                affinity: TextAffinity.downstream,
+              ),
+              composing: TextRange(start: -1, end: -1),
+            )
+          ], getter: imeClientGetter);
+
+          expect(
+            SuperEditorInspector.findTextInComponent('1').toPlainText(),
+            'Anonymous ',
+          );
+        });
+      });
+
+      group('on Samsung M51 (Android 12 SP1A) with GBoard', () {
+        testWidgetsOnAndroid('applies keyboard suggestions', (tester) async {
+          await tester //
+              .createDocument()
+              .withSingleEmptyParagraph()
+              .withInputSource(TextInputSource.ime)
+              .pump();
+
+          // Place the caret at the start of the paragraph.
+          await tester.placeCaretInParagraph('1', 0);
+
+          // Start typing the word "Anonymous" with typos.
+          await tester.typeImeText('Anonimoi');
+
+          // Simulate the user accepting a suggestion.
+          // The IME deletes the substring "imoi" and inserts "ymous ".
+          await tester.ime.sendDeltas(const [
             TextEditingDeltaDeletion(
-              oldText: '. Paragraph two',
-              deletedRange: TextRange(start: 1, end: 2),
-              selection: TextSelection.collapsed(offset: 1),
+              oldText: '. Anonimoi',
+              deletedRange: TextRange(start: 6, end: 10),
+              selection: TextSelection.collapsed(
+                offset: 4,
+                affinity: TextAffinity.downstream,
+              ),
               composing: TextRange(start: -1, end: -1),
             ),
-          ],
-          getter: imeClientGetter,
-        );
-
-        // Ensure the paragraph was merged.
-        expect(
-          (doc.getNodeAt(0)! as ParagraphNode).text.toPlainText(),
-          'Paragraph oneParagraph two',
-        );
-
-        // Ensure the selection is at "Paragraph one|Paragraph two".
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          DocumentSelection.collapsed(
-            position: DocumentPosition(
-              nodeId: doc.getNodeAt(0)!.id,
-              nodePosition: const TextNodePosition(offset: 13),
+            TextEditingDeltaInsertion(
+              oldText: '. Anon',
+              textInserted: 'ymous ',
+              insertionOffset: 6,
+              selection: TextSelection.collapsed(
+                offset: 12,
+                affinity: TextAffinity.downstream,
+              ),
+              composing: TextRange(start: -1, end: -1),
             ),
-          ),
-        );
+          ], getter: imeClientGetter);
+
+          expect(
+            SuperEditorInspector.findTextInComponent('1').toPlainText(),
+            'Anonymous ',
+          );
+        });
+      });
+
+      group('on Samsung', () {
+        testWidgetsOnAndroid('handles out of order newline followed by delta suggestion application', (tester) async {
+          await tester //
+              .createDocument()
+              .withSingleEmptyParagraph()
+              .withInputSource(TextInputSource.ime)
+              .pump();
+
+          // Place the caret at the start of the paragraph.
+          await tester.placeCaretInParagraph('1', 0);
+
+          // Start typing the word "Anonymous" with typos.
+          await tester.typeImeText('Anonimoi');
+
+          // Simulate the user pressing "newline", which on Samsung results in reporting
+          // the ENTER hardware key, followed by the suggestion deltas. Notice that these
+          // two events are in the wrong order!
+          await tester.pressEnter();
+
+          await tester.ime.sendDeltas(const [
+            TextEditingDeltaNonTextUpdate(
+              oldText: '. Anonimoi',
+              selection: TextSelection.collapsed(
+                offset: 10,
+                affinity: TextAffinity.downstream,
+              ),
+              composing: TextRange(start: 2, end: 10),
+            ),
+            TextEditingDeltaNonTextUpdate(
+              oldText: '. Anonimoi',
+              selection: TextSelection.collapsed(
+                offset: 10,
+                affinity: TextAffinity.downstream,
+              ),
+              composing: TextRange(start: 2, end: 10),
+            ),
+            TextEditingDeltaReplacement(
+              oldText: '. Anonimoi',
+              replacementText: 'Anonymous',
+              replacedRange: TextRange(start: 2, end: 10),
+              selection: TextSelection.collapsed(offset: 11, affinity: TextAffinity.downstream),
+              composing: TextRange(start: -1, end: -1),
+            ),
+          ], getter: imeClientGetter);
+
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.length, 2);
+          // Note: We expect the mis-spelled word to remain because we couldn't apply
+          //       the suggestion due to receiving events in the wrong order.
+          expect((document.first as TextNode).text.toPlainText(), 'Anonimoi');
+          expect((document.last as TextNode).text.toPlainText(), '');
+        });
+      });
+
+      group('GBoard >', () {
+        testWidgetsOnAndroid('can insert newline into empty paragraph', (tester) async {
+          // Verifies fix for GBoard empty paragraph newline bug:
+          // https://github.com/Flutter-Bounty-Hunters/super_editor/issues/2981
+
+          await tester //
+              .createDocument()
+              .withSingleEmptyParagraph()
+              .withInputSource(TextInputSource.ime)
+              .pump();
+
+          // Place the caret at the start of the paragraph.
+          await tester.placeCaretInParagraph('1', 0);
+
+          // Simulate press of the newline button.
+          //
+          // On GBoard this is reported as the ENTER key, followed by corrective dangling
+          // space removal deltas. Technically those deltas are sent out of order. This is
+          // because the empty paragraph is encoded as ". ".
+          await tester.pressEnter();
+
+          await tester.ime.sendDeltas(const [
+            // GBoard seems to send a bunch of identical non-text updates.
+            TextEditingDeltaNonTextUpdate(
+              oldText: '. ',
+              selection: TextSelection.collapsed(offset: 2),
+              composing: TextRange.empty,
+            ),
+            TextEditingDeltaNonTextUpdate(
+              oldText: '. ',
+              selection: TextSelection.collapsed(offset: 2),
+              composing: TextRange.empty,
+            ),
+            TextEditingDeltaNonTextUpdate(
+              oldText: '. ',
+              selection: TextSelection.collapsed(offset: 2),
+              composing: TextRange.empty,
+            ),
+            TextEditingDeltaNonTextUpdate(
+              oldText: '. ',
+              selection: TextSelection.collapsed(offset: 2),
+              composing: TextRange.empty,
+            ),
+            // After the non-text updates, there's a deletion delta that tries to remove the space.
+            TextEditingDeltaDeletion(
+              oldText: '. ',
+              deletedRange: TextRange(start: 1, end: 2),
+              selection: TextSelection.collapsed(
+                offset: 1,
+                affinity: TextAffinity.downstream,
+              ),
+              composing: TextRange(start: -1, end: -1),
+            ),
+          ], getter: imeClientGetter);
+
+          final document = SuperEditorInspector.findDocument();
+          expect(document, isNotNull);
+          expect(document!.length, 2);
+
+          expect(document.first, isA<ParagraphNode>());
+          expect((document.first as TextNode).text.toPlainText(), "");
+
+          expect(document.last, isA<ParagraphNode>());
+          expect((document.last as TextNode).text.toPlainText(), "");
+        });
       });
     });
 
-    group('on Samsung M51 (Android 12 SP1A)', () {
-      testWidgetsOnAndroid('applies keyboard suggestions', (tester) async {
+    group('iPhone >', () {
+      testWidgetsOnIos('can backspace an empty paragraph with deletion delta', (tester) async {
         await tester //
             .createDocument()
             .withSingleEmptyParagraph()
-            .withInputSource(TextInputSource.ime)
             .pump();
 
-        // Place the caret at the start of the paragraph.
+        // Place the caret in the first paragraph.
         await tester.placeCaretInParagraph('1', 0);
 
-        // Start typing the word "Anonymous" with typos.
-        await tester.typeImeText('Anonimoi');
+        // Create a second empty paragraph.
+        await tester.pressEnterWithIme(getter: imeClientGetter);
+        expect(SuperEditorInspector.findDocument()!.length, 2);
 
-        // Simulate the user accepting a suggestion.
-        // The IME replaces the word and inserts a space after it.
+        // Backspace to delete the 2nd empty paragraph. We run this deletion
+        // as its reported on iOS, to make sure that the iOS delta deletion
+        // approach doesn't conflict with our logic to ignore GBoard trailing
+        // space removal.
         await tester.ime.sendDeltas(const [
           TextEditingDeltaNonTextUpdate(
-            oldText: '. Anonimoi',
-            selection: TextSelection.collapsed(
-              offset: 10,
-              affinity: TextAffinity.downstream,
-            ),
-            composing: TextRange(start: 2, end: 10),
-          ),
-          TextEditingDeltaReplacement(
-            oldText: '. Anonimoi',
-            replacementText: 'Anonymous',
-            replacedRange: TextRange(start: 2, end: 10),
-            selection: TextSelection.collapsed(offset: 11, affinity: TextAffinity.downstream),
-            composing: TextRange(start: -1, end: -1),
-          ),
-          TextEditingDeltaInsertion(
-            oldText: '. Anonymous',
-            textInserted: ' ',
-            insertionOffset: 11,
-            selection: TextSelection.collapsed(
-              offset: 12,
-              affinity: TextAffinity.downstream,
-            ),
-            composing: TextRange(start: -1, end: -1),
-          )
-        ], getter: imeClientGetter);
-
-        expect(
-          SuperEditorInspector.findTextInComponent('1').toPlainText(),
-          'Anonymous ',
-        );
-      });
-    });
-
-    group('on Samsung M51 (Android 12 SP1A) with GBoard', () {
-      testWidgetsOnAndroid('applies keyboard suggestions', (tester) async {
-        await tester //
-            .createDocument()
-            .withSingleEmptyParagraph()
-            .withInputSource(TextInputSource.ime)
-            .pump();
-
-        // Place the caret at the start of the paragraph.
-        await tester.placeCaretInParagraph('1', 0);
-
-        // Start typing the word "Anonymous" with typos.
-        await tester.typeImeText('Anonimoi');
-
-        // Simulate the user accepting a suggestion.
-        // The IME deletes the substring "imoi" and inserts "ymous ".
-        await tester.ime.sendDeltas(const [
-          TextEditingDeltaDeletion(
-            oldText: '. Anonimoi',
-            deletedRange: TextRange(start: 6, end: 10),
-            selection: TextSelection.collapsed(
-              offset: 4,
-              affinity: TextAffinity.downstream,
-            ),
-            composing: TextRange(start: -1, end: -1),
-          ),
-          TextEditingDeltaInsertion(
-            oldText: '. Anon',
-            textInserted: 'ymous ',
-            insertionOffset: 6,
-            selection: TextSelection.collapsed(
-              offset: 12,
-              affinity: TextAffinity.downstream,
-            ),
-            composing: TextRange(start: -1, end: -1),
-          ),
-        ], getter: imeClientGetter);
-
-        expect(
-          SuperEditorInspector.findTextInComponent('1').toPlainText(),
-          'Anonymous ',
-        );
-      });
-    });
-
-    group('on Samsung', () {
-      testWidgetsOnAndroid('handles out of order newline followed by delta suggestion application', (tester) async {
-        await tester //
-            .createDocument()
-            .withSingleEmptyParagraph()
-            .withInputSource(TextInputSource.ime)
-            .pump();
-
-        // Place the caret at the start of the paragraph.
-        await tester.placeCaretInParagraph('1', 0);
-
-        // Start typing the word "Anonymous" with typos.
-        await tester.typeImeText('Anonimoi');
-
-        // Simulate the user pressing "newline", which on Samsung results in reporting
-        // the ENTER hardware key, followed by the suggestion deltas. Notice that these
-        // two events are in the wrong order!
-        await tester.pressEnter();
-
-        await tester.ime.sendDeltas(const [
-          TextEditingDeltaNonTextUpdate(
-            oldText: '. Anonimoi',
-            selection: TextSelection.collapsed(
-              offset: 10,
-              affinity: TextAffinity.downstream,
-            ),
-            composing: TextRange(start: 2, end: 10),
-          ),
-          TextEditingDeltaNonTextUpdate(
-            oldText: '. Anonimoi',
-            selection: TextSelection.collapsed(
-              offset: 10,
-              affinity: TextAffinity.downstream,
-            ),
-            composing: TextRange(start: 2, end: 10),
-          ),
-          TextEditingDeltaReplacement(
-            oldText: '. Anonimoi',
-            replacementText: 'Anonymous',
-            replacedRange: TextRange(start: 2, end: 10),
-            selection: TextSelection.collapsed(offset: 11, affinity: TextAffinity.downstream),
-            composing: TextRange(start: -1, end: -1),
-          ),
-        ], getter: imeClientGetter);
-
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.length, 2);
-        // Note: We expect the mis-spelled word to remain because we couldn't apply
-        //       the suggestion due to receiving events in the wrong order.
-        expect((document.first as TextNode).text.toPlainText(), 'Anonimoi');
-        expect((document.last as TextNode).text.toPlainText(), '');
-      });
-    });
-
-    group('GBoard >', () {
-      testWidgetsOnAndroid('can insert newline into empty paragraph', (tester) async {
-        // Verifies fix for GBoard empty paragraph newline bug:
-        // https://github.com/Flutter-Bounty-Hunters/super_editor/issues/2981
-
-        await tester //
-            .createDocument()
-            .withSingleEmptyParagraph()
-            .withInputSource(TextInputSource.ime)
-            .pump();
-
-        // Place the caret at the start of the paragraph.
-        await tester.placeCaretInParagraph('1', 0);
-
-        // Simulate press of the newline button.
-        //
-        // On GBoard this is reported as the ENTER key, followed by corrective dangling
-        // space removal deltas. Technically those deltas are sent out of order. This is
-        // because the empty paragraph is encoded as ". ".
-        await tester.pressEnter();
-
-        await tester.ime.sendDeltas(const [
-          // GBoard seems to send a bunch of identical non-text updates.
-          TextEditingDeltaNonTextUpdate(
             oldText: '. ',
-            selection: TextSelection.collapsed(offset: 2),
-            composing: TextRange.empty,
+            selection: TextSelection(baseOffset: 1, extentOffset: 2),
+            composing: TextRange(start: -1, end: -1),
           ),
-          TextEditingDeltaNonTextUpdate(
-            oldText: '. ',
-            selection: TextSelection.collapsed(offset: 2),
-            composing: TextRange.empty,
-          ),
-          TextEditingDeltaNonTextUpdate(
-            oldText: '. ',
-            selection: TextSelection.collapsed(offset: 2),
-            composing: TextRange.empty,
-          ),
-          TextEditingDeltaNonTextUpdate(
-            oldText: '. ',
-            selection: TextSelection.collapsed(offset: 2),
-            composing: TextRange.empty,
-          ),
-          // After the non-text updates, there's a deletion delta that tries to remove the space.
           TextEditingDeltaDeletion(
             oldText: '. ',
             deletedRange: TextRange(start: 1, end: 2),
@@ -779,301 +828,302 @@ Paragraph two
           ),
         ], getter: imeClientGetter);
 
-        final document = SuperEditorInspector.findDocument();
-        expect(document, isNotNull);
-        expect(document!.length, 2);
-
-        expect(document.first, isA<ParagraphNode>());
-        expect((document.first as TextNode).text.toPlainText(), "");
-
-        expect(document.last, isA<ParagraphNode>());
-        expect((document.last as TextNode).text.toPlainText(), "");
-      });
-    });
-
-    group('on iPhone 11 (iOS 13.7) with chinese keyboard', () {
-      testWidgetsOnIos('applies keyboard suggestions', (tester) async {
-        // Holds the composing region that we sent to the IME.
-        TextRange? composingRegion;
-
-        await tester //
-            .createDocument()
-            .withSingleEmptyParagraph()
-            .withInputSource(TextInputSource.ime)
-            .pump();
-
-        // Place the caret at the start of the paragraph.
-        await tester.placeCaretInParagraph('1', 0);
-
-        // Simulate the user typing "a a a".
-        await tester.ime.sendDeltas(const [
-          TextEditingDeltaNonTextUpdate(
-            oldText: '. ',
-            selection: TextSelection.collapsed(offset: 2),
-            composing: TextRange(start: -1, end: -1),
-          ),
-          TextEditingDeltaInsertion(
-            oldText: '. ',
-            textInserted: 'a',
-            insertionOffset: 2,
-            selection: TextSelection.collapsed(
-              offset: 3,
-              affinity: TextAffinity.upstream,
-            ),
-            composing: TextRange(start: 2, end: 3),
-          ),
-        ], getter: imeClientGetter);
-        await tester.ime.sendDeltas(const [
-          TextEditingDeltaInsertion(
-            oldText: '. a',
-            textInserted: ' a',
-            insertionOffset: 3,
-            selection: TextSelection.collapsed(
-              offset: 5,
-              affinity: TextAffinity.upstream,
-            ),
-            composing: TextRange(start: 2, end: 5),
-          ),
-        ], getter: imeClientGetter);
-        await tester.ime.sendDeltas(const [
-          TextEditingDeltaInsertion(
-            oldText: '. a a',
-            textInserted: ' a',
-            insertionOffset: 5,
-            selection: TextSelection.collapsed(
-              offset: 7,
-              affinity: TextAffinity.upstream,
-            ),
-            composing: TextRange(start: 2, end: 7),
-          ),
-        ], getter: imeClientGetter);
-
-        // Simulate the user accepting the suggestion from the keyboard.
-        //
-        // The IME sends the replacement and changes the composing region in the same frame,
-        // in separate delta batches.
-        final imeClient = imeClientGetter();
-        imeClient.updateEditingValueWithDeltas(const [
-          TextEditingDeltaReplacement(
-            oldText: '. a a a',
-            replacementText: '呵呵呵',
-            replacedRange: TextRange(start: 2, end: 7),
-            selection: TextSelection.collapsed(
-              offset: 5,
-              affinity: TextAffinity.upstream,
-            ),
-            composing: TextRange(start: 2, end: 5),
-          ),
-        ]);
-
-        // Intercept the setEditingState message sent to the platform so we can check
-        // which composing region was sent.
-        tester
-            .interceptChannel(SystemChannels.textInput.name) //
-            .interceptMethod(
-          'TextInput.setEditingState',
-          (methodCall) {
-            final params = methodCall.arguments as Map;
-            composingRegion = TextRange(
-              start: params['composingBase'],
-              end: params['composingExtent'],
-            );
-            return null;
-          },
-        );
-
-        imeClient.updateEditingValueWithDeltas(const [
-          TextEditingDeltaNonTextUpdate(
-            oldText: '. 呵呵呵',
-            selection: TextSelection.collapsed(
-              offset: 5,
-              affinity: TextAffinity.upstream,
-            ),
-            composing: TextRange.empty,
-          ),
-        ]);
-        await tester.pump();
-
-        // Between the two updateEditingValueWithDeltas calls, the IME interactor
-        // sends [0, 3) as the new composing region (the composing region of the first delta) to the IME.
-        //
-        // If the user types with that composing region, all the existing text is replaced.
-        //
-        // Ensure we cleared the composing region on the IME so the previous entered text is preserved.
-        expect(composingRegion, TextRange.empty);
-      });
-
-      testWidgetsOnIos('applies keyboard suggestions and keeps styles', (tester) async {
-        // Pump an editor with a bold text.
-        final testContext = await tester //
-            .createDocument()
-            .fromMarkdown('**Fix**')
-            .withInputSource(TextInputSource.ime)
-            .pump();
-
-        // Place the caret at the end of the paragraph.
-        await tester.placeCaretInParagraph(testContext.document.first.id, 3);
-
-        // Type a letter simulating a typo. The current text results in "Fixs".
-        await tester.typeImeText('s');
-
-        // Simulate the user accepting a suggestion.
-        // The IME replaces the word and inserts a space after it.
-        await tester.ime.sendDeltas([
-          const TextEditingDeltaReplacement(
-            oldText: '. Fixs',
-            replacementText: 'Fixed',
-            replacedRange: TextRange(start: 2, end: 6),
-            selection: TextSelection.collapsed(offset: 7),
-            composing: TextRange(start: -1, end: -1),
-          ),
-        ], getter: imeClientGetter);
-        await tester.ime.sendDeltas([
-          const TextEditingDeltaInsertion(
-            oldText: '. Fixed',
-            textInserted: ' ',
-            insertionOffset: 7,
-            selection: TextSelection.collapsed(offset: 8),
-            composing: TextRange(start: -1, end: -1),
-          )
-        ], getter: imeClientGetter);
-
-        // Ensure the text was replaced and the style was preserved.
-        expect(testContext.document, equalsMarkdown('**Fixed **'));
-      });
-    });
-
-    group('on iPhone 13 (iOS 17.2) with korean keyboard', () {
-      testWidgetsOnIos('applies keyboard suggestions', (tester) async {
-        await tester //
-            .createDocument()
-            .withSingleEmptyParagraph()
-            .withInputSource(TextInputSource.ime)
-            .pump();
-
-        // Place the caret at the start of the paragraph.
-        await tester.placeCaretInParagraph('1', 0);
-
-        // Simulate the user typing "ㅅ".
-        await tester.ime.sendDeltas(const [
-          TextEditingDeltaNonTextUpdate(
-            oldText: '. ',
-            selection: TextSelection.collapsed(offset: 2),
-            composing: TextRange(start: -1, end: -1),
-          ),
-          TextEditingDeltaInsertion(
-            oldText: '. ',
-            textInserted: 'ㅅ',
-            insertionOffset: 2,
-            selection: TextSelection.collapsed(offset: 3, affinity: TextAffinity.downstream),
-            composing: TextRange(start: -1, end: -1),
-          ),
-        ], getter: imeClientGetter);
-
-        // Simulate the user typing "ㅛ" and the IME converting the "ㅅㅛ" to "쇼".
-        await tester.ime.sendDeltas(const [
-          TextEditingDeltaNonTextUpdate(
-            oldText: '. ㅅ',
-            selection: TextSelection(baseOffset: 1, extentOffset: 3, isDirectional: false),
-            composing: TextRange(start: -1, end: -1),
-          ),
-          TextEditingDeltaDeletion(
-            oldText: '. ㅅ',
-            deletedRange: TextRange(start: 1, end: 3),
-            selection: TextSelection.collapsed(
-              offset: 1,
-              affinity: TextAffinity.downstream,
-            ),
-            composing: TextRange(start: -1, end: -1),
-          ),
-          TextEditingDeltaInsertion(
-            oldText: '.',
-            textInserted: ' ',
-            insertionOffset: 1,
-            selection: TextSelection.collapsed(
-              offset: 2,
-              affinity: TextAffinity.downstream,
-            ),
-            composing: TextRange(start: -1, end: -1),
-          ),
-          TextEditingDeltaInsertion(
-            oldText: '. ',
-            textInserted: '쇼',
-            insertionOffset: 2,
-            selection: TextSelection.collapsed(
-              offset: 3,
-              affinity: TextAffinity.downstream,
-            ),
-            composing: TextRange(start: -1, end: -1),
-          )
-        ], getter: imeClientGetter);
-
-        // Ensure text and selection were updated.
-        expect(SuperEditorInspector.findTextInComponent('1').toPlainText(), '쇼');
+        // Ensure that we deleted the 2nd paragraph and moved back up to the first.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.length, 1);
+        expect(document.first.id, "1");
         expect(
           SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 1),
-              ),
-            ),
+          const DocumentSelection.collapsed(
+            position: DocumentPosition(nodeId: "1", nodePosition: TextNodePosition(offset: 0)),
           ),
         );
       });
-    });
 
-    group('on iPhone 15 (iOS 17.5)', () {
-      testWidgetsOnIos('ignores keyboard suggestions when pressing the newline button', (tester) async {
-        final testContext = await tester //
-            .createDocument()
-            .withSingleEmptyParagraph()
-            .withInputSource(TextInputSource.ime)
-            .pump();
+      group('on iPhone 11 (iOS 13.7) with chinese keyboard', () {
+        testWidgetsOnIos('applies keyboard suggestions', (tester) async {
+          // Holds the composing region that we sent to the IME.
+          TextRange? composingRegion;
 
-        // Place the caret at the start of the paragraph.
-        await tester.placeCaretInParagraph('1', 0);
+          await tester //
+              .createDocument()
+              .withSingleEmptyParagraph()
+              .withInputSource(TextInputSource.ime)
+              .pump();
 
-        // Type some text.
-        await tester.typeImeText('run tom');
+          // Place the caret at the start of the paragraph.
+          await tester.placeCaretInParagraph('1', 0);
 
-        // Press the new line button.
-        await tester.testTextInput.receiveAction(TextInputAction.newline);
-
-        // Simulate the IME sending a delta replacing "tom" with "Tom".
-        // At this point, we already added a new paragraph to the document,
-        // so these text ranges are invalid for us.
-        await tester.ime.sendDeltas([
-          const TextEditingDeltaReplacement(
-            oldText: '. Run tom',
-            replacementText: 'Tom',
-            replacedRange: TextRange(start: 6, end: 9),
-            selection: TextSelection.collapsed(offset: 9),
-            composing: TextRange(start: -1, end: -1),
-          ),
-        ], getter: imeClientGetter);
-
-        await tester.ime.sendDeltas([
-          const TextEditingDeltaInsertion(
-            oldText: '. Run Tom',
-            textInserted: '\n',
-            insertionOffset: 9,
-            selection: TextSelection.collapsed(
-              offset: 10,
-              affinity: TextAffinity.downstream,
+          // Simulate the user typing "a a a".
+          await tester.ime.sendDeltas(const [
+            TextEditingDeltaNonTextUpdate(
+              oldText: '. ',
+              selection: TextSelection.collapsed(offset: 2),
+              composing: TextRange(start: -1, end: -1),
             ),
-            composing: TextRange(start: -1, end: -1),
-          ),
-        ], getter: imeClientGetter);
-        await tester.pump();
+            TextEditingDeltaInsertion(
+              oldText: '. ',
+              textInserted: 'a',
+              insertionOffset: 2,
+              selection: TextSelection.collapsed(
+                offset: 3,
+                affinity: TextAffinity.upstream,
+              ),
+              composing: TextRange(start: 2, end: 3),
+            ),
+          ], getter: imeClientGetter);
+          await tester.ime.sendDeltas(const [
+            TextEditingDeltaInsertion(
+              oldText: '. a',
+              textInserted: ' a',
+              insertionOffset: 3,
+              selection: TextSelection.collapsed(
+                offset: 5,
+                affinity: TextAffinity.upstream,
+              ),
+              composing: TextRange(start: 2, end: 5),
+            ),
+          ], getter: imeClientGetter);
+          await tester.ime.sendDeltas(const [
+            TextEditingDeltaInsertion(
+              oldText: '. a a',
+              textInserted: ' a',
+              insertionOffset: 5,
+              selection: TextSelection.collapsed(
+                offset: 7,
+                affinity: TextAffinity.upstream,
+              ),
+              composing: TextRange(start: 2, end: 7),
+            ),
+          ], getter: imeClientGetter);
 
-        final document = testContext.document;
+          // Simulate the user accepting the suggestion from the keyboard.
+          //
+          // The IME sends the replacement and changes the composing region in the same frame,
+          // in separate delta batches.
+          final imeClient = imeClientGetter();
+          imeClient.updateEditingValueWithDeltas(const [
+            TextEditingDeltaReplacement(
+              oldText: '. a a a',
+              replacementText: '呵呵呵',
+              replacedRange: TextRange(start: 2, end: 7),
+              selection: TextSelection.collapsed(
+                offset: 5,
+                affinity: TextAffinity.upstream,
+              ),
+              composing: TextRange(start: 2, end: 5),
+            ),
+          ]);
 
-        // Ensure the replacement was ignored and a new empty node was added.
-        expect(document.nodeCount, 2);
-        expect((document.getNodeAt(0)! as TextNode).text.toPlainText(), 'run tom');
-        expect((document.getNodeAt(1)! as TextNode).text.toPlainText(), '');
+          // Intercept the setEditingState message sent to the platform so we can check
+          // which composing region was sent.
+          tester
+              .interceptChannel(SystemChannels.textInput.name) //
+              .interceptMethod(
+            'TextInput.setEditingState',
+            (methodCall) {
+              final params = methodCall.arguments as Map;
+              composingRegion = TextRange(
+                start: params['composingBase'],
+                end: params['composingExtent'],
+              );
+              return null;
+            },
+          );
+
+          imeClient.updateEditingValueWithDeltas(const [
+            TextEditingDeltaNonTextUpdate(
+              oldText: '. 呵呵呵',
+              selection: TextSelection.collapsed(
+                offset: 5,
+                affinity: TextAffinity.upstream,
+              ),
+              composing: TextRange.empty,
+            ),
+          ]);
+          await tester.pump();
+
+          // Between the two updateEditingValueWithDeltas calls, the IME interactor
+          // sends [0, 3) as the new composing region (the composing region of the first delta) to the IME.
+          //
+          // If the user types with that composing region, all the existing text is replaced.
+          //
+          // Ensure we cleared the composing region on the IME so the previous entered text is preserved.
+          expect(composingRegion, TextRange.empty);
+        });
+
+        testWidgetsOnIos('applies keyboard suggestions and keeps styles', (tester) async {
+          // Pump an editor with a bold text.
+          final testContext = await tester //
+              .createDocument()
+              .fromMarkdown('**Fix**')
+              .withInputSource(TextInputSource.ime)
+              .pump();
+
+          // Place the caret at the end of the paragraph.
+          await tester.placeCaretInParagraph(testContext.document.first.id, 3);
+
+          // Type a letter simulating a typo. The current text results in "Fixs".
+          await tester.typeImeText('s');
+
+          // Simulate the user accepting a suggestion.
+          // The IME replaces the word and inserts a space after it.
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaReplacement(
+              oldText: '. Fixs',
+              replacementText: 'Fixed',
+              replacedRange: TextRange(start: 2, end: 6),
+              selection: TextSelection.collapsed(offset: 7),
+              composing: TextRange(start: -1, end: -1),
+            ),
+          ], getter: imeClientGetter);
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaInsertion(
+              oldText: '. Fixed',
+              textInserted: ' ',
+              insertionOffset: 7,
+              selection: TextSelection.collapsed(offset: 8),
+              composing: TextRange(start: -1, end: -1),
+            )
+          ], getter: imeClientGetter);
+
+          // Ensure the text was replaced and the style was preserved.
+          expect(testContext.document, equalsMarkdown('**Fixed **'));
+        });
+      });
+
+      group('on iPhone 13 (iOS 17.2) with korean keyboard', () {
+        testWidgetsOnIos('applies keyboard suggestions', (tester) async {
+          await tester //
+              .createDocument()
+              .withSingleEmptyParagraph()
+              .withInputSource(TextInputSource.ime)
+              .pump();
+
+          // Place the caret at the start of the paragraph.
+          await tester.placeCaretInParagraph('1', 0);
+
+          // Simulate the user typing "ㅅ".
+          await tester.ime.sendDeltas(const [
+            TextEditingDeltaNonTextUpdate(
+              oldText: '. ',
+              selection: TextSelection.collapsed(offset: 2),
+              composing: TextRange(start: -1, end: -1),
+            ),
+            TextEditingDeltaInsertion(
+              oldText: '. ',
+              textInserted: 'ㅅ',
+              insertionOffset: 2,
+              selection: TextSelection.collapsed(offset: 3, affinity: TextAffinity.downstream),
+              composing: TextRange(start: -1, end: -1),
+            ),
+          ], getter: imeClientGetter);
+
+          // Simulate the user typing "ㅛ" and the IME converting the "ㅅㅛ" to "쇼".
+          await tester.ime.sendDeltas(const [
+            TextEditingDeltaNonTextUpdate(
+              oldText: '. ㅅ',
+              selection: TextSelection(baseOffset: 1, extentOffset: 3, isDirectional: false),
+              composing: TextRange(start: -1, end: -1),
+            ),
+            TextEditingDeltaDeletion(
+              oldText: '. ㅅ',
+              deletedRange: TextRange(start: 1, end: 3),
+              selection: TextSelection.collapsed(
+                offset: 1,
+                affinity: TextAffinity.downstream,
+              ),
+              composing: TextRange(start: -1, end: -1),
+            ),
+            TextEditingDeltaInsertion(
+              oldText: '.',
+              textInserted: ' ',
+              insertionOffset: 1,
+              selection: TextSelection.collapsed(
+                offset: 2,
+                affinity: TextAffinity.downstream,
+              ),
+              composing: TextRange(start: -1, end: -1),
+            ),
+            TextEditingDeltaInsertion(
+              oldText: '. ',
+              textInserted: '쇼',
+              insertionOffset: 2,
+              selection: TextSelection.collapsed(
+                offset: 3,
+                affinity: TextAffinity.downstream,
+              ),
+              composing: TextRange(start: -1, end: -1),
+            )
+          ], getter: imeClientGetter);
+
+          // Ensure text and selection were updated.
+          expect(SuperEditorInspector.findTextInComponent('1').toPlainText(), '쇼');
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 1),
+                ),
+              ),
+            ),
+          );
+        });
+      });
+
+      group('on iPhone 15 (iOS 17.5)', () {
+        testWidgetsOnIos('ignores keyboard suggestions when pressing the newline button', (tester) async {
+          final testContext = await tester //
+              .createDocument()
+              .withSingleEmptyParagraph()
+              .withInputSource(TextInputSource.ime)
+              .pump();
+
+          // Place the caret at the start of the paragraph.
+          await tester.placeCaretInParagraph('1', 0);
+
+          // Type some text.
+          await tester.typeImeText('run tom');
+
+          // Press the new line button.
+          await tester.testTextInput.receiveAction(TextInputAction.newline);
+
+          // Simulate the IME sending a delta replacing "tom" with "Tom".
+          // At this point, we already added a new paragraph to the document,
+          // so these text ranges are invalid for us.
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaReplacement(
+              oldText: '. Run tom',
+              replacementText: 'Tom',
+              replacedRange: TextRange(start: 6, end: 9),
+              selection: TextSelection.collapsed(offset: 9),
+              composing: TextRange(start: -1, end: -1),
+            ),
+          ], getter: imeClientGetter);
+
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaInsertion(
+              oldText: '. Run Tom',
+              textInserted: '\n',
+              insertionOffset: 9,
+              selection: TextSelection.collapsed(
+                offset: 10,
+                affinity: TextAffinity.downstream,
+              ),
+              composing: TextRange(start: -1, end: -1),
+            ),
+          ], getter: imeClientGetter);
+          await tester.pump();
+
+          final document = testContext.document;
+
+          // Ensure the replacement was ignored and a new empty node was added.
+          expect(document.nodeCount, 2);
+          expect((document.getNodeAt(0)! as TextNode).text.toPlainText(), 'run tom');
+          expect((document.getNodeAt(1)! as TextNode).text.toPlainText(), '');
+        });
       });
     });
 


### PR DESCRIPTION
[Super Editor][iOS][IME] - Fix: Can't backspace empty text nodes on iOS (Resolves #2989)

I broke this when I recently created a heuristic to weed out aggressive trailing space removal by the GBoard. But that heuristic also captures legitimate backspacing by iOS: https://github.com/Flutter-Bounty-Hunters/super_editor/pull/2982