### PR TITLE
[Super Editor][Mobile][Bug] - Show popover toolbar on tablets and other non-software keyboard situations (Resolves #2994)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -430,6 +430,7 @@ class AndroidDocumentTouchInteractor extends StatefulWidget {
     required this.document,
     required this.getDocumentLayout,
     required this.selection,
+    required this.isImeConnected,
     this.openKeyboardWhenTappingExistingSelection = true,
     this.openKeyboardOnSelectionChange = true,
     required this.openSoftwareKeyboard,
@@ -448,6 +449,14 @@ class AndroidDocumentTouchInteractor extends StatefulWidget {
   final Document document;
   final DocumentLayout Function() getDocumentLayout;
   final ValueListenable<DocumentSelection?> selection;
+
+  /// A listenable that reports whether the IME is currently connected to this
+  /// editor, which means either a software keyboard or hardware keyboard is
+  /// currently configured to edit the document in this editor.
+  ///
+  /// This signal is used, for example, to decide whether we should show
+  /// the popover toolbar on tap.
+  final ValueListenable<bool> isImeConnected;
 
   /// {@macro openKeyboardWhenTappingExistingSelection}
   final bool openKeyboardWhenTappingExistingSelection;
@@ -994,8 +1003,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
         ..hideMagnifier()
         ..blinkCaret();
 
-      if (didTapOnExistingSelection &&
-          SuperKeyboard.instance.mobileGeometry.value.keyboardState == KeyboardState.open) {
+      if (didTapOnExistingSelection && widget.isImeConnected.value) {
         // Toggle the toolbar display when the user taps on the collapsed caret,
         // or on top of an existing selection.
         //
@@ -1343,6 +1351,7 @@ class SuperEditorAndroidControlsOverlayManager extends StatefulWidget {
     required this.getDocumentLayout,
     required this.selection,
     required this.setSelection,
+    required this.isImeConnected,
     required this.scrollChangeSignal,
     required this.dragHandleAutoScroller,
     this.defaultToolbarBuilder,
@@ -1357,6 +1366,14 @@ class SuperEditorAndroidControlsOverlayManager extends StatefulWidget {
   final DocumentLayoutResolver getDocumentLayout;
   final ValueListenable<DocumentSelection?> selection;
   final void Function(DocumentSelection?) setSelection;
+
+  /// A listenable that reports whether the IME is currently connected to this
+  /// editor, which means either a software keyboard or hardware keyboard is
+  /// currently configured to edit the document in this editor.
+  ///
+  /// This signal is used to, for example, to decide whether we should show
+  /// the popover toolbar on tap.
+  final ValueListenable<bool> isImeConnected;
 
   final SignalNotifier scrollChangeSignal;
 
@@ -1533,6 +1550,13 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
   }
 
   void _toggleToolbarOnCollapsedHandleTap() {
+    if (!widget.isImeConnected.value) {
+      // We have a selection with a handle, but no IME connection. This probably
+      // shouldn't happen, but in general, we don't want to support content changes
+      // without a connection to the OS IME.
+      return;
+    }
+
     _controlsController!.toggleToolbar();
   }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -266,6 +266,7 @@ class IosDocumentTouchInteractor extends StatefulWidget {
     required this.document,
     required this.getDocumentLayout,
     required this.selection,
+    required this.isImeConnected,
     this.openKeyboardWhenTappingExistingSelection = true,
     this.openKeyboardOnSelectionChange = true,
     required this.openSoftwareKeyboard,
@@ -284,6 +285,14 @@ class IosDocumentTouchInteractor extends StatefulWidget {
   final Document document;
   final DocumentLayout Function() getDocumentLayout;
   final ValueListenable<DocumentSelection?> selection;
+
+  /// A listenable that reports whether the IME is currently connected to this
+  /// editor, which means either a software keyboard or hardware keyboard is
+  /// currently configured to edit the document in this editor.
+  ///
+  /// This signal is used to, for example, to decide whether we should show
+  /// the popover toolbar on tap.
+  final ValueListenable<bool> isImeConnected;
 
   /// {@macro openKeyboardWhenTappingExistingSelection}
   final bool openKeyboardWhenTappingExistingSelection;
@@ -371,6 +380,10 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
 
     widget.document.addListener(_onDocumentChange);
 
+    widget.focusNode.addListener(_onFocusChange);
+
+    widget.isImeConnected.addListener(_onImeConnectionChange);
+
     _floatingCursorListener = FloatingCursorListener(
       onStart: _onFloatingCursorStart,
       onStop: _onFloatingCursorStop,
@@ -407,6 +420,20 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
       oldWidget.document.removeListener(_onDocumentChange);
       widget.document.addListener(_onDocumentChange);
     }
+
+    if (widget.focusNode != oldWidget.focusNode) {
+      oldWidget.focusNode.removeListener(_onFocusChange);
+      widget.focusNode.addListener(_onFocusChange);
+    }
+
+    if (widget.isImeConnected != oldWidget.isImeConnected) {
+      oldWidget.isImeConnected.removeListener(_onImeConnectionChange);
+      widget.isImeConnected.addListener(_onImeConnectionChange);
+
+      if (oldWidget.isImeConnected.value != widget.isImeConnected.value) {
+        _onImeConnectionChange();
+      }
+    }
   }
 
   @override
@@ -416,6 +443,10 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     _controlsController!.floatingCursorController.removeListener(_floatingCursorListener);
     _controlsController!.floatingCursorController.cursorGeometryInViewport
         .removeListener(_onFloatingCursorGeometryChange);
+
+    widget.isImeConnected.removeListener(_onImeConnectionChange);
+
+    widget.focusNode.removeListener(_onFocusChange);
 
     widget.document.removeListener(_onDocumentChange);
 
@@ -447,6 +478,23 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     onNextFrame((_) {
       _ensureSelectionExtentIsVisible();
     });
+  }
+
+  void _onFocusChange() {
+    if (!widget.focusNode.hasFocus) {
+      // Overlay controls shouldn't be visible when there's no focus.
+      _controlsController
+        ?..hideToolbar()
+        ..hideMagnifier();
+    }
+  }
+
+  void _onImeConnectionChange() {
+    if (!widget.isImeConnected.value) {
+      // Our editor doesn't have an IME connection. Ensure that our visual state
+      // is acceptable when we don't have an open IME connection.
+      _controlsController?.hideToolbar();
+    }
   }
 
   void _ensureSelectionExtentIsVisible() {
@@ -662,8 +710,7 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
           selection.extent.nodeId == docPosition.nodeId &&
           selection.extent.nodePosition.isEquivalentTo(docPosition.nodePosition);
 
-      if (didTapOnExistingSelection &&
-          SuperKeyboard.instance.mobileGeometry.value.keyboardState == KeyboardState.open) {
+      if (didTapOnExistingSelection && widget.isImeConnected.value) {
         // Toggle the toolbar display when the user taps on the collapsed caret,
         // or on top of an existing selection.
         //

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -919,6 +919,7 @@ class SuperEditorState extends State<SuperEditor> {
               ),
             ]);
           },
+          isImeConnected: _isImeConnected,
           scrollChangeSignal: _scrollChangeSignal,
           dragHandleAutoScroller: _dragHandleAutoScroller,
           defaultToolbarBuilder: (overlayContext, mobileToolbarKey, focalPoint) => defaultAndroidEditorToolbarBuilder(
@@ -966,6 +967,7 @@ class SuperEditorState extends State<SuperEditor> {
           document: editContext.document,
           getDocumentLayout: () => editContext.documentLayout,
           selection: editContext.composer.selectionNotifier,
+          isImeConnected: _isImeConnected,
           openKeyboardWhenTappingExistingSelection: widget.selectionPolicies.openKeyboardWhenTappingExistingSelection,
           openKeyboardOnSelectionChange: widget.imePolicies.openKeyboardOnSelectionChange,
           openSoftwareKeyboard: _openSoftwareKeyboard,
@@ -987,6 +989,7 @@ class SuperEditorState extends State<SuperEditor> {
           document: editContext.document,
           getDocumentLayout: () => editContext.documentLayout,
           selection: editContext.composer.selectionNotifier,
+          isImeConnected: _isImeConnected,
           openKeyboardWhenTappingExistingSelection: widget.selectionPolicies.openKeyboardWhenTappingExistingSelection,
           openKeyboardOnSelectionChange: widget.imePolicies.openKeyboardOnSelectionChange,
           openSoftwareKeyboard: _openSoftwareKeyboard,

--- a/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
@@ -69,7 +69,31 @@ void main() {
       await tester.pump(kTapMinTime);
     });
 
-    testWidgetsOnAndroid("shows and hides toolbar upon tap on collapsed handle", (tester) async {
+    testWidgetsOnAndroid("toggles toolbar upon tap on caret (with software keyboard)", (tester) async {
+      await _pumpSingleParagraphApp(tester);
+
+      // Place the caret at the beginning of the document.
+      await tester.tapInParagraph("1", 0);
+
+      // Ensure the toolbar isn't visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+
+      // Tap the caret to show the toolbar.
+      await tester.tapInParagraph("1", 0);
+      await tester.pump();
+
+      // Ensure the toolbar is visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+
+      // Tap the caret to hide the toolbar.
+      await tester.tapOnCollapsedMobileHandle();
+      await tester.pump();
+
+      // Ensure the toolbar isn't visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+    });
+
+    testWidgetsOnAndroid("toggles toolbar upon tap on collapsed handle (with software keyboard)", (tester) async {
       await _pumpSingleParagraphApp(tester);
 
       // Place the caret at the beginning of the document.
@@ -90,6 +114,110 @@ void main() {
       await tester.pump();
 
       // Ensure the toolbar isn't visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+    });
+
+    testWidgetsOnAndroid("hides toolbar when the IME connection closes (with software keyboard)", (tester) async {
+      await _pumpSingleParagraphApp(tester);
+
+      // Place the caret at the beginning of the document.
+      await tester.tapInParagraph("1", 0);
+
+      // Ensure the toolbar isn't visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+
+      // Tap the caret to show the toolbar.
+      await tester.tapInParagraph("1", 0);
+      await tester.pump();
+
+      // Ensure the toolbar is visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+
+      // Take the IME connection away from Super Editor. The best we can do to
+      // simulate this is to move the focus somewhere else. In practice, this is
+      // how it actually occurs. It's not obvious under which circumstances the OS
+      // forcibly reclaims the IME, or how we should simulate that in tests.
+      FocusManager.instance.primaryFocus?.unfocus();
+      await tester.pump();
+      await tester.pump();
+
+      // Ensure that the toolbar is hidden.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+    });
+
+    testWidgetsOnAndroid("toggles toolbar upon tap on caret (with hardware keyboard)", (tester) async {
+      await _pumpSingleParagraphApp(tester, simulateSoftwareKeyboardAppearance: false);
+
+      // Place the caret at the beginning of the document.
+      await tester.tapInParagraph("1", 0);
+
+      // Ensure the toolbar isn't visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+
+      // Tap the caret to show the toolbar.
+      await tester.tapInParagraph("1", 0);
+      await tester.pump();
+
+      // Ensure the toolbar is visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+
+      // Tap the caret to hide the toolbar.
+      await tester.tapOnCollapsedMobileHandle();
+      await tester.pump();
+
+      // Ensure the toolbar isn't visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+    });
+
+    testWidgetsOnAndroid("toggles toolbar upon tap on collapsed handle (with hardware keyboard)", (tester) async {
+      await _pumpSingleParagraphApp(tester, simulateSoftwareKeyboardAppearance: false);
+
+      // Place the caret at the beginning of the document.
+      await tester.placeCaretInParagraph("1", 0);
+
+      // Ensure the toolbar isn't visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+
+      // Tap the drag handle to show the toolbar.
+      await tester.tapOnCollapsedMobileHandle();
+      await tester.pump();
+
+      // Ensure the toolbar is visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+
+      // Tap the drag handle to hide the toolbar.
+      await tester.tapOnCollapsedMobileHandle();
+      await tester.pump();
+
+      // Ensure the toolbar isn't visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+    });
+
+    testWidgetsOnAndroid("hides toolbar when the IME connection closes (with hardware keyboard)", (tester) async {
+      await _pumpSingleParagraphApp(tester, simulateSoftwareKeyboardAppearance: false);
+
+      // Place the caret at the beginning of the document.
+      await tester.tapInParagraph("1", 0);
+
+      // Ensure the toolbar isn't visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+
+      // Tap the caret to show the toolbar.
+      await tester.tapInParagraph("1", 0);
+      await tester.pump();
+
+      // Ensure the toolbar is visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+
+      // Take the IME connection away from Super Editor. The best we can do to
+      // simulate this is to move the focus somewhere else. In practice, this is
+      // how it actually occurs. It's not obvious under which circumstances the OS
+      // forcibly reclaims the IME, or how we should simulate that in tests.
+      FocusManager.instance.primaryFocus?.unfocus();
+      await tester.pump();
+      await tester.pump();
+
+      // Ensure that the toolbar is hidden.
       expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
     });
 
@@ -716,10 +844,14 @@ void main() {
   });
 }
 
-Future<TestDocumentContext> _pumpSingleParagraphApp(WidgetTester tester) async {
+Future<TestDocumentContext> _pumpSingleParagraphApp(
+  WidgetTester tester, {
+  bool simulateSoftwareKeyboardAppearance = true,
+}) async {
   return await tester
       .createDocument()
       // Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor...
       .withSingleParagraph()
+      .simulateSoftwareKeyboardInsets(simulateSoftwareKeyboardAppearance)
       .pump();
 }

--- a/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
@@ -23,7 +25,7 @@ void main() {
       expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
     });
 
-    testWidgetsOnIos("shows toolbar when tapping on caret", (tester) async {
+    testWidgetsOnIos("toggles toolbar when tapping on caret (with software keyboard)", (tester) async {
       await _pumpSingleParagraphApp(tester);
 
       // Place the caret at the end of a word, because iOS snaps the caret
@@ -39,6 +41,101 @@ void main() {
 
       // Ensure that the toolbar is visible.
       expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
+
+      // Tap on the caret again, to toggle the toolbar off.
+      await tester.tapInParagraph("1", 207);
+
+      // Ensure that the toolbar is hidden.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
+    });
+
+    testWidgetsOnIos("hides toolbar when IME connection is closed (with software keyboard)", (tester) async {
+      await _pumpSingleParagraphApp(tester);
+
+      // Place the caret at the end of a word, because iOS snaps the caret
+      // to word boundaries by default.
+      await tester.tapInParagraph("1", 207);
+
+      // Ensure all controls are hidden.
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+
+      // Tap again on the caret.
+      await tester.tapInParagraph("1", 207);
+
+      // Ensure that the toolbar is visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
+
+      // Take the IME connection away from Super Editor. The best we can do to
+      // simulate this is to move the focus somewhere else. In practice, this is
+      // how it actually occurs. It's not obvious under which circumstances the OS
+      // forcibly reclaims the IME, or how we should simulate that in tests.
+      FocusManager.instance.primaryFocus?.unfocus();
+      await tester.pump();
+      await tester.pump();
+
+      // Ensure that the toolbar is hidden.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
+    });
+
+    testWidgetsOnIos("toggles toolbar when tapping on caret (with hardware keyboard)", (tester) async {
+      await _pumpSingleParagraphApp(tester, simulateSoftwareKeyboardAppearance: false);
+
+      // Place the caret at the end of a word, because iOS snaps the caret
+      // to word boundaries by default.
+      await tester.tapInParagraph("1", 207);
+
+      // Ensure all controls are hidden.
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+
+      // Tap again on the caret.
+      await tester.tapInParagraph("1", 207);
+
+      // Ensure that the toolbar is visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
+
+      // Tap on the caret again, to toggle the toolbar off.
+      await tester.tapInParagraph("1", 207);
+
+      // Ensure that the toolbar is hidden.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
+    });
+
+    testWidgetsOnIos("hides toolbar when IME connection is closed (with hardware keyboard)", (tester) async {
+      await _pumpSingleParagraphApp(tester, simulateSoftwareKeyboardAppearance: false);
+
+      // Place the caret at the end of a word, because iOS snaps the caret
+      // to word boundaries by default.
+      await tester.tapInParagraph("1", 207);
+
+      // Ensure all controls are hidden.
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+
+      // Tap again on the caret.
+      await tester.tapInParagraph("1", 207);
+
+      // Ensure that the toolbar is visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
+
+      // Take the IME connection away from Super Editor. The best we can do to
+      // simulate this is to move the focus somewhere else. In practice, this is
+      // how it actually occurs. It's not obvious under which circumstances the OS
+      // forcibly reclaims the IME, or how we should simulate that in tests.
+      FocusManager.instance.primaryFocus?.unfocus();
+      await tester.pump();
+      await tester.pump();
+
+      // Ensure that the toolbar is hidden.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
       expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
     });
 
@@ -409,12 +506,15 @@ void main() {
   });
 }
 
-Future<void> _pumpSingleParagraphApp(WidgetTester tester) async {
+Future<void> _pumpSingleParagraphApp(
+  WidgetTester tester, {
+  bool simulateSoftwareKeyboardAppearance = true,
+}) async {
   await tester
       .createDocument()
       // Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor...
       .withSingleParagraph()
-      .simulateSoftwareKeyboardInsets(true)
+      .simulateSoftwareKeyboardInsets(simulateSoftwareKeyboardAppearance)
       .useIosSelectionHeuristics(true)
       .pump();
 }


### PR DESCRIPTION
[Super Editor][Mobile][Bug] - Show popover toolbar on tablets and other non-software keyboard situations (Resolves #2994)

We previously configured the overlay controls to only show when `SuperKeyboard` reports the keyboard is open. But this prevents the toolbar from showing up when external keyboards are used, which is especially common on tablets.

This PR changes the logic from "is keyboard open" to "is IME connected".