### PR TITLE
[AttributedText] Improve performance of getAttributionSpansInRange

### DIFF
--- a/attributed_text/lib/src/attributed_spans.dart
+++ b/attributed_text/lib/src/attributed_spans.dart
@@ -227,7 +227,12 @@ class AttributedSpans {
       } else {
         // Is there a start marker matching this end marker?
         final spanStart = openSpans.remove(marker.attribution.id);
-        if (spanStart == null) continue;
+        if (spanStart == null) {
+          // We don't have a start marker for this end marker. This is
+          // because this attribution failed the `attributionFilter`. We
+          // don't care about it.
+          continue;
+        }
 
         final spanEnd = marker.offset;
 

--- a/attributed_text/lib/src/attributed_spans.dart
+++ b/attributed_text/lib/src/attributed_spans.dart
@@ -216,8 +216,10 @@ class AttributedSpans {
         if (spanStart == null) continue;
 
         final spanEnd = marker.offset;
+
+        // Does span overlap requested range?
         if (spanStart <= end && spanEnd >= start) {
-          // Span overlaps requested range.
+          // Add the span to the set. Duplicate are automatically ignored.
           matchingAttributionSpans.add(AttributionSpan(
             attribution: marker.attribution,
             start: resizeSpansToFitInRange ? max(spanStart, start) : spanStart,

--- a/attributed_text/lib/src/attributed_spans.dart
+++ b/attributed_text/lib/src/attributed_spans.dart
@@ -93,22 +93,36 @@ class AttributedSpans {
     required int start,
     required int end,
   }) {
-    if (attributions.isEmpty) return {};
+    if (attributions.isEmpty) {
+      return {};
+    }
 
-    final matchingIds = {for (final a in attributions) a.id};
+    final desiredIds = {
+      for (final a in attributions) //
+        a.id
+    };
     final matchingAttributions = <Attribution>{};
     final Map<String, int> openSpans = {};
 
     for (final marker in _markers) {
       if (marker.isStart) {
-        if (matchingIds.contains(marker.attribution.id)) {
+        if (desiredIds.contains(marker.attribution.id)) {
+          // We found the start of an attribution span we're interested in.
           openSpans[marker.attribution.id] = marker.offset;
         }
       } else {
         final spanStart = openSpans.remove(marker.attribution.id);
-        if (spanStart == null) continue;
+        if (spanStart == null) {
+          // We haven't found a corresponding start to this attribution range that
+          // we care about. This means that this is not one of the `attributions`
+          // we're looking for. Skip it.
+          continue;
+        }
 
         if (spanStart <= end && marker.offset >= start) {
+          // We found the end of an attribution span we're interested in. Also,
+          // that span starts and ends within the range of interest. Add this
+          // attribution to the set we return.
           matchingAttributions.add(marker.attribution);
         }
       }

--- a/attributed_text/lib/src/attributed_spans.dart
+++ b/attributed_text/lib/src/attributed_spans.dart
@@ -93,17 +93,27 @@ class AttributedSpans {
     required int start,
     required int end,
   }) {
+    if (attributions.isEmpty) return {};
+
+    final matchingIds = {for (final a in attributions) a.id};
     final matchingAttributions = <Attribution>{};
-    for (int i = start; i <= end; ++i) {
-      for (final attribution in attributions) {
-        final otherAttributions = getAllAttributionsAt(i);
-        for (final otherAttribution in otherAttributions) {
-          if (otherAttribution.id == attribution.id) {
-            matchingAttributions.add(otherAttribution);
-          }
+    final Map<String, int> openSpans = {};
+
+    for (final marker in _markers) {
+      if (marker.isStart) {
+        if (matchingIds.contains(marker.attribution.id)) {
+          openSpans[marker.attribution.id] = marker.offset;
+        }
+      } else {
+        final spanStart = openSpans.remove(marker.attribution.id);
+        if (spanStart == null) continue;
+
+        if (spanStart <= end && marker.offset >= start) {
+          matchingAttributions.add(marker.attribution);
         }
       }
     }
+
     return matchingAttributions;
   }
 

--- a/attributed_text/lib/src/attributed_spans.dart
+++ b/attributed_text/lib/src/attributed_spans.dart
@@ -193,27 +193,26 @@ class AttributedSpans {
     bool resizeSpansToFitInRange = false,
   }) {
     final matchingAttributionSpans = <AttributionSpan>{};
+    final Map<String, int> openSpans = {};
 
-    // For every unit in the given range...
-    for (int i = start; i <= end; ++i) {
-      final attributionsAtOffset = getAllAttributionsAt(i);
-      // For every attribution overlaps this unit...
-      for (final attribution in attributionsAtOffset) {
-        // If the caller wants this attribution...
-        if (attributionFilter(attribution)) {
-          // Calculate the span for this attribution.
-          AttributionSpan span = expandAttributionToSpan(
-            attribution: attribution,
-            offset: i,
-          );
+    for (final marker in _markers) {
+      if (marker.isStart) {
+        if (attributionFilter(marker.attribution)) {
+          openSpans[marker.attribution.id] = marker.offset;
+        }
+      } else {
+        // If there is start marker matching this end marker.
+        final spanStart = openSpans.remove(marker.attribution.id);
+        if (spanStart == null) continue;
 
-          // If desired, resize the span to fit within the range.
-          if (resizeSpansToFitInRange) {
-            span = span.constrain(start: start, end: end);
-          }
-
-          // Add the span to the set. Duplicate are automatically ignored.
-          matchingAttributionSpans.add(span);
+        final spanEnd = marker.offset;
+        if (spanStart <= end && spanEnd >= start) {
+          // Span overlaps requested range.
+          matchingAttributionSpans.add(AttributionSpan(
+            attribution: marker.attribution,
+            start: resizeSpansToFitInRange ? max(spanStart, start) : spanStart,
+            end: resizeSpansToFitInRange ? min(spanEnd, end) : spanEnd,
+          ));
         }
       }
     }

--- a/attributed_text/lib/src/attributed_spans.dart
+++ b/attributed_text/lib/src/attributed_spans.dart
@@ -201,7 +201,7 @@ class AttributedSpans {
           openSpans[marker.attribution.id] = marker.offset;
         }
       } else {
-        // If there is start marker matching this end marker.
+        // Is there a start marker matching this end marker?
         final spanStart = openSpans.remove(marker.attribution.id);
         if (spanStart == null) continue;
 

--- a/attributed_text/test/attributed_text_test.dart
+++ b/attributed_text/test/attributed_text_test.dart
@@ -348,12 +348,12 @@ void main() {
         expect(ranges.length, 4);
         expect(
           ranges,
-          [
+          {
             const AttributionSpan(attribution: ExpectedSpans.bold, start: 2, end: 3),
             const AttributionSpan(attribution: ExpectedSpans.italics, start: 5, end: 7),
             const AttributionSpan(attribution: ExpectedSpans.bold, start: 6, end: 7),
             const AttributionSpan(attribution: ExpectedSpans.italics, start: 9, end: 10),
-          ],
+          },
         );
       });
 


### PR DESCRIPTION
`AttributedSpans.getAttributionSpansInRange` frequently appears in a hot codepath and current implementation seems to have cubic complexity. This PR replaces it with simpler implementation that only traverses the attributes once.