### PR TITLE
[Super Editor][Adjustment] - Upgrade super editor to use attributed text v0.4.6, also export BlinkController and BlinkTimingMode from super_text_layout

### DIFF
--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -2,6 +2,7 @@ library super_editor;
 
 export 'package:attributed_text/attributed_text.dart';
 export 'package:super_text_layout/src/caret_layer.dart';
+export 'package:super_text_layout/super_text_layout.dart' show BlinkController, BlinkTimingMode;
 
 // Fundamental document abstractions
 export 'src/core/document.dart';

--- a/super_editor/lib/super_text_field.dart
+++ b/super_editor/lib/super_text_field.dart
@@ -1,5 +1,7 @@
 library super_text_field;
 
+export 'package:super_text_layout/super_text_layout.dart' show BlinkController, BlinkTimingMode;
+
 // The whole text field.
 export 'src/super_textfield/super_textfield.dart';
 

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  attributed_text: ^0.4.5
+  attributed_text: ^0.4.6
   characters: ^1.3.0
   collection: ^1.15.0
   dart_quill_delta: ^9.4.1

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  attributed_text: ^0.4.6
+  attributed_text: ^0.4.7
   characters: ^1.3.0
   collection: ^1.15.0
   dart_quill_delta: ^9.4.1


### PR DESCRIPTION
[Super Editor][Adjustment] - Upgrade super editor to use attributed text v0.4.6, also export BlinkController and BlinkTimingMode from super_text_layout