### PR TITLE
Fix regression in SuperEditor pattern tags test

### DIFF
--- a/attributed_text/lib/src/attributed_spans.dart
+++ b/attributed_text/lib/src/attributed_spans.dart
@@ -108,7 +108,7 @@ class AttributedSpans {
       if (marker.isStart) {
         if (desiredIds.contains(marker.attribution.id)) {
           // We found the start of an attribution span we're interested in.
-          openSpans[marker.attribution.id] = marker.offset;
+          openSpans[marker.attribution.id] ??= marker.offset;
         }
       } else {
         final spanStart = openSpans.remove(marker.attribution.id);
@@ -222,7 +222,7 @@ class AttributedSpans {
     for (final marker in _markers) {
       if (marker.isStart) {
         if (attributionFilter(marker.attribution)) {
-          openSpans[marker.attribution.id] = marker.offset;
+          openSpans[marker.attribution.id] ??= marker.offset;
         }
       } else {
         // Is there a start marker matching this end marker?


### PR DESCRIPTION
New implementation of `getAttributionSpansInRange` diverged from original in case when there are multiple start markers for single attribution without an end marker in-between. I didn't think that was an expected situation but apparently it happens at least temporarily.

This PR fixes the issue by not overwriting the first start marker.