### PR TITLE
Fix Android popover backspace

### DIFF
--- a/super_editor/lib/src/default_editor/document_hardware_keyboard/document_physical_keyboard.dart
+++ b/super_editor/lib/src/default_editor/document_hardware_keyboard/document_physical_keyboard.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:super_editor/src/core/edit_context.dart';
@@ -69,7 +70,7 @@ class _SuperEditorHardwareKeyHandlerState extends State<SuperEditorHardwareKeyHa
   }
 
   KeyEventResult _onKeyPressed(FocusNode node, KeyEvent keyEvent) {
-    if (!node.hasPrimaryFocus) {
+    if (!node.hasPrimaryFocus && !_shouldHandleNonPrimaryFocusKey(keyEvent)) {
       // The editor is focused, but doesn't have primary focus. For example:
       // - The editor has a node with a focused widget.
       // - There is a focused widget somewhere else in the tree which shares
@@ -95,6 +96,14 @@ class _SuperEditorHardwareKeyHandlerState extends State<SuperEditorHardwareKeyHa
       case ExecutionInstruction.blocked:
         return KeyEventResult.ignored;
     }
+  }
+
+  bool _shouldHandleNonPrimaryFocusKey(KeyEvent keyEvent) {
+    // Android's software keyboard can report backspace through the hardware key pipeline
+    // while a popover has primary focus.
+    return defaultTargetPlatform == TargetPlatform.android &&
+        (keyEvent is KeyDownEvent || keyEvent is KeyRepeatEvent) &&
+        keyEvent.logicalKey == LogicalKeyboardKey.backspace;
   }
 
   @override

--- a/super_editor/test/super_editor/supereditor_keyboard_test.dart
+++ b/super_editor/test/super_editor/supereditor_keyboard_test.dart
@@ -411,6 +411,54 @@ void main() {
         ),
       );
     });
+
+    testWidgetsOnAndroid('handles backspace when a popover has primary focus', (tester) async {
+      final editorFocusNode = FocusNode();
+      final popoverFocusNode = FocusNode();
+      final overlayController = OverlayPortalController();
+
+      final testContext = await tester //
+          .createDocument()
+          .fromMarkdown("This is some testing text.") // Length is 26
+          .withFocusNode(editorFocusNode)
+          .withInputSource(TextInputSource.ime)
+          .withCustomWidgetTreeBuilder(
+            (superEditor) => MaterialApp(
+              home: Scaffold(
+                body: OverlayPortal(
+                  controller: overlayController,
+                  overlayChildBuilder: (context) => Focus(
+                    focusNode: popoverFocusNode,
+                    parentNode: editorFocusNode,
+                    child: const SizedBox(width: 100, height: 100),
+                  ),
+                  child: superEditor,
+                ),
+              ),
+            ),
+          )
+          .pump();
+
+      final nodeId = testContext.findEditContext().document.first.id;
+      await tester.placeCaretInParagraph(nodeId, 5);
+
+      overlayController.show();
+      popoverFocusNode.requestFocus();
+      await tester.pump();
+
+      expect(editorFocusNode.hasFocus, isTrue);
+      expect(editorFocusNode.hasPrimaryFocus, isFalse);
+      expect(popoverFocusNode.hasPrimaryFocus, isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.backspace);
+      await tester.pumpAndSettle();
+
+      expect(SuperEditorInspector.findTextInComponent(nodeId).toPlainText(), "Thisis some testing text.");
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        selectionEquivalentTo(_caretInParagraph(nodeId, 4)),
+      );
+    });
   });
 
   group('SuperEditor software keyboard', () {


### PR DESCRIPTION
Fixes #2936.

Android backspace now reaches SuperEditor when a popover has primary focus.

Other keys still stay with the popover.

Tests pass: analyze, keyboard test, full test.