### PR TITLE
Cherry Pick (to stable): [SuperEditor][Mobile] - Don't let desktop caret tick on mobile (Resolves #3037)

### DIFF
--- a/super_editor/lib/src/default_editor/document_caret_overlay.dart
+++ b/super_editor/lib/src/default_editor/document_caret_overlay.dart
@@ -21,7 +21,7 @@ class CaretDocumentOverlay extends DocumentLayoutLayerStatefulWidget {
     this.platformOverride,
     this.displayOnAllPlatforms = false,
     this.displayCaretWithExpandedSelection = true,
-    this.blinkTimingMode = BlinkTimingMode.ticker,
+    this.blinkTimingMode = BlinkTimingMode.timer,
   }) : super(key: key);
 
   /// The editor's [DocumentComposer], which reports the current selection.
@@ -99,6 +99,9 @@ class CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentOv
   }
 
   @visibleForTesting
+  bool get isCaretTicking => _blinkController.isBlinking;
+
+  @visibleForTesting
   bool get isCaretVisible => _blinkController.opacity == 1.0 && !_shouldHideCaretForExpandedSelection;
 
   /// Returns `true` if the selection is currently expanded, and we want to hide the caret when
@@ -124,8 +127,17 @@ class CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentOv
   }
 
   void _startOrStopBlinking() {
+    final isDesktop = switch (defaultTargetPlatform) {
+      TargetPlatform.iOS => false,
+      TargetPlatform.android => false,
+      TargetPlatform.linux => true,
+      TargetPlatform.macOS => true,
+      TargetPlatform.windows => true,
+      TargetPlatform.fuchsia => true,
+    };
+
     // TODO: allow a configurable policy as to whether to show the caret at all when the selection is expanded: https://github.com/superlistapp/super_editor/issues/234
-    final wantsToBlink = widget.composer.selection != null;
+    final wantsToBlink = widget.composer.selection != null && (widget.displayOnAllPlatforms || isDesktop);
     if (wantsToBlink && _blinkController.isBlinking) {
       return;
     }

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -1411,7 +1411,7 @@ class DefaultCaretOverlayBuilder implements SuperEditorLayerBuilder {
     this.platformOverride,
     this.displayOnAllPlatforms = false,
     this.displayCaretWithExpandedSelection = true,
-    this.blinkTimingMode = BlinkTimingMode.ticker,
+    this.blinkTimingMode = BlinkTimingMode.timer,
   });
 
   /// Styles applied to the caret that's painted by this caret overlay.

--- a/super_editor/test/super_editor/supereditor_caret_test.dart
+++ b/super_editor/test/super_editor/supereditor_caret_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
-import 'package:super_text_layout/super_text_layout.dart';
 
 void main() {
   group("SuperEditor", () {
@@ -371,6 +370,36 @@ void main() {
 
       // Ensure that the caret is no longer visible.
       expect(SuperEditorInspector.isCaretVisible(), false);
+    });
+
+    testWidgetsOnMobile("does not try to blink desktop caret on mobile", (tester) async {
+      // Configure BlinkController to animate, otherwise it won't blink.
+      BlinkController.indeterminateAnimationsEnabled = true;
+      addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
+
+      await tester //
+          .createDocument()
+          .withSingleEmptyParagraph()
+          .pump();
+
+      // Tap to place the caret at the beginning of the document.
+      // We don't use the robot method here because it calls pumpAndSettle,
+      // which causes a pumpAndSettle timeout, because we are constantly
+      // scheduling frames.
+      await tester.tap(find.byType(SuperEditor));
+      await tester.pump();
+
+      // Ensure mobile caret is visible.
+      expect(SuperEditorInspector.isCaretVisible(), true);
+
+      // Ensure desktop caret is not trying to blink. This check is about the Ticker/Timer,
+      // not the visual caret.
+      final desktopCaretState =
+          (find.byType(CaretDocumentOverlay).evaluate().first as StatefulElement).state as CaretDocumentOverlayState;
+      expect(desktopCaretState.isCaretTicking, isFalse);
+
+      // Settle so that the gesture recognizer from the tap finishes.
+      await tester.pumpAndSettle();
     });
   });
 }


### PR DESCRIPTION
Cherry Pick (to stable): [SuperEditor][Mobile] - Don't let desktop caret tick on mobile (Resolves #3037)

Original PR: https://github.com/Flutter-Bounty-Hunters/super_editor/pull/3038