### PR TITLE
Cherry Pick: [SuperEditor][Markdown] - Reverse part of the previous PR where we made every TextNode 'left' aligned by default, which broke RTL (#3045)

### DIFF
--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -15,8 +15,13 @@ import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/core/editor.dart';
 import 'package:super_editor/src/core/styles.dart';
 import 'package:super_editor/src/default_editor/attributions.dart';
+import 'package:super_editor/src/default_editor/layout_single_column/layout_single_column.dart';
+import 'package:super_editor/src/default_editor/multi_node_editing.dart';
+import 'package:super_editor/src/default_editor/paragraph.dart';
+import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
 import 'package:super_editor/src/default_editor/text/custom_underlines.dart';
 import 'package:super_editor/src/default_editor/text_ai.dart';
+import 'package:super_editor/src/default_editor/text_tools.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/attributed_text_styles.dart';
 import 'package:super_editor/src/infrastructure/composable_text.dart';
@@ -26,30 +31,13 @@ import 'package:super_editor/src/infrastructure/keyboard.dart';
 import 'package:super_editor/src/infrastructure/strings.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
-import 'layout_single_column/layout_single_column.dart';
-import 'multi_node_editing.dart';
-import 'paragraph.dart';
-import 'selection_upstream_downstream.dart';
-import 'text_tools.dart';
-
 @immutable
 class TextNode extends DocumentNode {
   TextNode({
     required this.id,
     required this.text,
     super.metadata,
-  }) {
-    if (metadata['textAlign'] == null) {
-      initAddToMetadata({
-        'textAlign': 'left',
-      });
-    } else {
-      assert(
-        metadata['textAlign'] is String?,
-        'Expected "textAlign" metadata to be of type String, but got: ${metadata['textAlign']}',
-      );
-    }
-  }
+  });
 
   @override
   final String id;

--- a/super_editor/lib/src/infrastructure/serialization/markdown/markdown_to_document_parsing.dart
+++ b/super_editor/lib/src/infrastructure/serialization/markdown/markdown_to_document_parsing.dart
@@ -108,7 +108,9 @@ MutableDocument deserializeMarkdownToDocument(
   final hangingEmptyLines = markdownLines.reversed.takeWhile((line) => _blankLinePattern.hasMatch(line.content));
   if (hangingEmptyLines.isNotEmpty && documentNodes.lastOrNull is ListItemNode) {
     for (var i = 0; i < hangingEmptyLines.length ~/ 2; i++) {
-      documentNodes.add(ParagraphNode(id: Editor.createNodeId(), text: AttributedText()));
+      documentNodes.add(
+        ParagraphNode(id: Editor.createNodeId(), text: AttributedText()),
+      );
     }
   }
 
@@ -346,7 +348,8 @@ class _MarkdownToDocument implements md.NodeVisitor {
         text: _parseInlineText(element.textContent),
         metadata: {
           'blockType': headerAttribution,
-          'textAlign': element.attributes['textAlign'] ?? 'left',
+          if (element.attributes['textAlign'] != null) //
+            'textAlign': element.attributes['textAlign'],
         },
       ),
     );
@@ -358,7 +361,8 @@ class _MarkdownToDocument implements md.NodeVisitor {
         id: Editor.createNodeId(),
         text: attributedText,
         metadata: {
-          'textAlign': attributes['textAlign'] ?? 'left',
+          if (attributes['textAlign'] != null) //
+            'textAlign': attributes['textAlign'],
         },
       ),
     );

--- a/super_editor/test/infrastructure/serialization/markdown/super_editor_markdown_test.dart
+++ b/super_editor/test/infrastructure/serialization/markdown/super_editor_markdown_test.dart
@@ -1689,7 +1689,7 @@ with multiple lines
         final doc = deserializeMarkdownToDocument('---:');
 
         final paragraph = doc.first as ParagraphNode;
-        expect(paragraph.getMetadataValue('textAlign'), "left");
+        expect(paragraph.getMetadataValue('textAlign'), null);
         expect(paragraph.text.toPlainText(), '---:');
       });
 
@@ -1697,7 +1697,7 @@ with multiple lines
         final doc = deserializeMarkdownToDocument('---:\n - - -');
 
         final paragraph = doc.first as ParagraphNode;
-        expect(paragraph.getMetadataValue('textAlign'), "left");
+        expect(paragraph.getMetadataValue('textAlign'), null);
         expect(paragraph.text.toPlainText(), '---:');
 
         // Ensure the horizontal rule is parsed.
@@ -1708,7 +1708,7 @@ with multiple lines
         final doc = deserializeMarkdownToDocument(':---\nParagraph1', syntax: MarkdownSyntax.normal);
 
         final paragraph = doc.first as ParagraphNode;
-        expect(paragraph.getMetadataValue('textAlign'), "left");
+        expect(paragraph.getMetadataValue('textAlign'), null);
         expect(paragraph.text.toPlainText(), ':---\nParagraph1');
       });
 

--- a/super_editor/test/infrastructure/serialization/quill/parsing/parsing_test.dart
+++ b/super_editor/test/infrastructure/serialization/quill/parsing/parsing_test.dart
@@ -79,10 +79,10 @@ void main() {
         nodes.moveNext();
         node = nodes.current;
 
-        // Paragraph - left aligned.
+        // Paragraph - default alignment.
         expect(node, isA<ParagraphNode>());
         expect((node as TextNode).text.toPlainText(), "Left aligned");
-        expect(node.metadata["textAlign"], "left");
+        expect(node.metadata["textAlign"], null);
 
         nodes.moveNext();
         node = nodes.current;

--- a/super_editor_clipboard/test/copy_and_paste_test.dart
+++ b/super_editor_clipboard/test/copy_and_paste_test.dart
@@ -194,12 +194,10 @@ void main() {
                 ParagraphNode(
                   id: editor.document.getNodeAt(1)!.id,
                   text: AttributedText("Two"),
-                  metadata: {'textAlign': null},
                 ),
                 ParagraphNode(
                   id: editor.document.getNodeAt(2)!.id,
                   text: AttributedText("Three"),
-                  metadata: {'textAlign': null},
                 ),
               ],
             ),
@@ -253,7 +251,6 @@ void main() {
                 ParagraphNode(
                   id: editor.document.getNodeAt(1)!.id,
                   text: AttributedText("Two"),
-                  metadata: {'textAlign': null},
                 ),
                 ParagraphNode(
                   id: editor.document.getNodeAt(2)!.id,


### PR DESCRIPTION
[SuperEditor][Markdown] - Reverse part of the previous PR where we made every TextNode 'left' aligned by default, which broke RTL (#3045)