### PR TITLE
[Super Editor][Super Text Layout] - Fix lost ticker in BlinkController (Resolves #3050)

### DIFF
--- a/super_editor/lib/src/default_editor/document_caret_overlay.dart
+++ b/super_editor/lib/src/default_editor/document_caret_overlay.dart
@@ -81,6 +81,17 @@ class CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentOv
   void didUpdateWidget(CaretDocumentOverlay oldWidget) {
     super.didUpdateWidget(oldWidget);
 
+    if (widget.blinkTimingMode != oldWidget.blinkTimingMode) {
+      _blinkController.dispose();
+
+      switch (widget.blinkTimingMode) {
+        case BlinkTimingMode.ticker:
+          _blinkController = BlinkController(tickerProvider: this);
+        case BlinkTimingMode.timer:
+          _blinkController = BlinkController.withTimer();
+      }
+    }
+
     if (widget.composer != oldWidget.composer) {
       oldWidget.composer.selectionNotifier.removeListener(_onSelectionChange);
       widget.composer.selectionNotifier.addListener(_onSelectionChange);

--- a/super_text_layout/lib/src/infrastructure/blink_controller.dart
+++ b/super_text_layout/lib/src/infrastructure/blink_controller.dart
@@ -37,7 +37,13 @@ class BlinkController with ChangeNotifier {
   Ticker? _ticker;
   Duration _lastBlinkTime = Duration.zero;
 
+  @visibleForTesting
+  bool get isTicking => _ticker?.isTicking ?? false;
+
   Timer? _timer;
+
+  @visibleForTesting
+  bool get isTimerRunning => _timer?.isActive ?? false;
 
   final Duration _flashPeriod;
 
@@ -93,7 +99,6 @@ class BlinkController with ChangeNotifier {
     if (_ticker != null) {
       // We're using a Ticker to blink. Stop it.
       _ticker?.stop();
-      _ticker = null;
     } else {
       // We're using a Timer to blink. Stop it.
       _timer?.cancel();

--- a/super_text_layout/test/blink_controller_test.dart
+++ b/super_text_layout/test/blink_controller_test.dart
@@ -7,12 +7,12 @@ void main() {
       bool hasNotifiedItsListener = false;
 
       final blinkController = BlinkController(tickerProvider: tester);
-      blinkController.addListener(() { 
+      blinkController.addListener(() {
         hasNotifiedItsListener = true;
-      });      
-      
+      });
+
       blinkController.stopBlinking();
-      
+
       // Ensure that the callback was called
       expect(hasNotifiedItsListener, true);
     });
@@ -21,23 +21,21 @@ void main() {
       // Configure BlinkController to animate, otherwise it won't blink
       BlinkController.indeterminateAnimationsEnabled = true;
 
-      bool hasNotifiedItsListeners = false;      
-      
-      final blinkController = BlinkController(
-        tickerProvider: tester
-      );      
+      bool hasNotifiedItsListeners = false;
+
+      final blinkController = BlinkController(tickerProvider: tester);
       blinkController.stopBlinking();
 
-      blinkController.addListener(() { 
+      blinkController.addListener(() {
         hasNotifiedItsListeners = true;
-      });      
-      
+      });
+
       blinkController.startBlinking();
 
       // Ensure that the callback was called
       expect(hasNotifiedItsListeners, true);
 
-      // Release the ticker      
+      // Release the ticker
       blinkController.stopBlinking();
       BlinkController.indeterminateAnimationsEnabled = false;
     });
@@ -49,32 +47,65 @@ void main() {
       const flashPeriod = Duration(milliseconds: 500);
 
       int notificationCount = 0;
-      
-      final blinkController = BlinkController(
-        tickerProvider: tester, 
-        flashPeriod: flashPeriod
-      );
-      blinkController.addListener(() { 
+
+      final blinkController = BlinkController(tickerProvider: tester, flashPeriod: flashPeriod);
+      blinkController.addListener(() {
         notificationCount++;
-      });      
-      
+      });
+
       blinkController.startBlinking();
 
-      // Ensure that the callback was called before the first blink 
+      // Ensure that the callback was called before the first blink
       expect(notificationCount, 1);
-      
+
       // Trigger the first frame, otherwise we get a zero elapsedTime in the _onTick method
       await tester.pump();
       // Trigger a frame with an ellapsed time greater than the flashPeriod,
       // so the controller should change its visible state and notify its listeners
       await tester.pump(flashPeriod + const Duration(milliseconds: 1));
-    
+
       // Ensure that the callback was called a second time
       expect(notificationCount, 2);
 
-      // Release the ticker      
+      // Release the ticker
       blinkController.stopBlinking();
       BlinkController.indeterminateAnimationsEnabled = false;
+    });
+
+    testWidgets("can stop and then restart ticker", (tester) async {
+      // Configure BlinkController to animate, otherwise it won't blink
+      BlinkController.indeterminateAnimationsEnabled = true;
+
+      int notificationCount = 0;
+
+      final blinkController = BlinkController(tickerProvider: tester);
+      blinkController.addListener(() {
+        notificationCount += 1;
+      });
+
+      blinkController.startBlinking();
+      expect(notificationCount, 1);
+
+      // Ensure the ticker is ticking.
+      expect(blinkController.isTicking, isTrue);
+
+      // Stop the blinking, which should stop the ticker, but should retain the ticker.
+      blinkController.stopBlinking();
+      expect(notificationCount, 2);
+
+      // Ensure that the ticker is no longer ticking.
+      expect(blinkController.isTicking, isFalse);
+      expect(blinkController.isTimerRunning, isFalse);
+
+      blinkController.startBlinking();
+      expect(notificationCount, 3);
+
+      // Ensure that the ticker is running again, and that we're not using a timer.
+      expect(blinkController.isTicking, isTrue);
+      expect(blinkController.isTimerRunning, isFalse);
+
+      // Dispose the controller so that we don't leak the ticker and cause a test error.
+      blinkController.dispose();
     });
   });
 }


### PR DESCRIPTION
[Super Editor][Super Text Layout] - Fix lost ticker in BlinkController (Resolves #3050)

In `super_text_layout` in the `BlinkController` we were null'ing out the `Ticker` when we stop blinking, but we shouldn't do that, because then we never recreate it. Now, we stop the `Ticker`, but we don't dispose it or null it out until the controller is disposed.

Also, in `super_editor`, in the `CaretDocumentOverlay`, we weren't handling widget changes from ticker to timer, or timer to ticker. This PR adds that support.