### PR TITLE
[Super Editor][Chat] - Workaround for nuanced bottom insets calculation bug in keyboard panel scaffold (Resolves #3070)

### DIFF
--- a/super_editor/lib/src/chat/bottom_floating/default/default_editor_sheet.dart
+++ b/super_editor/lib/src/chat/bottom_floating/default/default_editor_sheet.dart
@@ -89,7 +89,6 @@ class _DefaultFloatingEditorSheetState extends State<DefaultFloatingEditorSheet>
   double _dragTouchOffsetFromIndicator = 0;
 
   void _onVerticalDragStart(DragStartDetails details) {
-    print("Drag handle start: ${details.globalPosition}");
     _dragTouchOffsetFromIndicator = _dragFingerOffsetFromIndicator(details.globalPosition);
 
     widget.messagePageController.onDragStart(
@@ -98,19 +97,16 @@ class _DefaultFloatingEditorSheetState extends State<DefaultFloatingEditorSheet>
   }
 
   void _onVerticalDragUpdate(DragUpdateDetails details) {
-    print("Drag handle update: ${details.globalPosition}");
     widget.messagePageController.onDragUpdate(
       details.globalPosition.dy - _dragIndicatorOffsetFromTop - _dragTouchOffsetFromIndicator,
     );
   }
 
   void _onVerticalDragEnd(DragEndDetails details) {
-    print("Drag handle end.");
     widget.messagePageController.onDragEnd();
   }
 
   void _onVerticalDragCancel() {
-    print("Drag handle cancel.");
     widget.messagePageController.onDragEnd();
   }
 

--- a/super_editor/lib/src/chat/bottom_floating/ui_kit/floating_editor_page_scaffold.dart
+++ b/super_editor/lib/src/chat/bottom_floating/ui_kit/floating_editor_page_scaffold.dart
@@ -563,9 +563,7 @@ class _AboveKeyboardMessagePageElement<PanelType> extends RenderObjectElement {
   }
 
   void updateOrInflateKeyboardPanel() {
-    print("updateOrInflateKeyboardPanel()");
     final panel = widget.pageController.openPanel;
-    print(" - open panel: $panel");
     if (panel == null) {
       if (_keyboardPanel == null) {
         return;
@@ -576,15 +574,12 @@ class _AboveKeyboardMessagePageElement<PanelType> extends RenderObjectElement {
         // The panel is hidden behind a fully open keyboard, or the panel has already
         // completely closed. Either way, we can now remove it from the UI without any
         // visual disturbance.
-        print("REMOVING PANEL FROM ELEMENT");
-        print(" - keyboard state: ${SuperKeyboard.instance.mobileGeometry.value.keyboardState}");
         _keyboardPanel = updateChild(_keyboardPanel, null, _keyboardPanelSlot);
         _lastBuiltPanel = null;
         _waitingForPanelAnimationToCompleteBeforeRemoval = false;
         return;
       } else {
         // The panel is animating closed. We want to let it finish the animation.
-        print("WAITING FOR PANEL TO CLOSE");
         _keyboardPanel = updateChild(
           _keyboardPanel,
           widget.keyboardPanelBuilder!(this, _lastBuiltPanel!),
@@ -595,7 +590,6 @@ class _AboveKeyboardMessagePageElement<PanelType> extends RenderObjectElement {
       }
     }
 
-    print("BUILDING PANEL WIDGET FOR: $panel");
     if (_keyboardPanel == null) {
       _keyboardPanel = inflateWidget(
         widget.keyboardPanelBuilder!(this, panel),
@@ -622,7 +616,6 @@ class _AboveKeyboardMessagePageElement<PanelType> extends RenderObjectElement {
     // remove the panel without any visual disturbance.
     //
     // The update method already knows how to remove the panel, so we defer it.
-    print("PANEL ANIMATION CLOSED - REMOVING THE PANEL");
     updateOrInflateKeyboardPanel();
   }
 
@@ -639,7 +632,6 @@ class _AboveKeyboardMessagePageElement<PanelType> extends RenderObjectElement {
     // remove the panel without any visual disturbance.
     //
     // The update method already knows how to remove the panel, so we defer it.
-    print("KEYBOARD OPENED - REMOVING THE PANEL");
     updateOrInflateKeyboardPanel();
   }
 
@@ -847,7 +839,6 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
       duration: const Duration(milliseconds: 250),
     )
       ..addListener(() {
-        print("Panel height change: ${_panelHeightController.value}%");
         markNeedsLayout();
       })
       ..addStatusListener((status) {
@@ -943,7 +934,6 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
   double _animatedVelocity = 0;
 
   void _attachToPageController() {
-    print("ATTACHING TO PAGE CONTROLLER (${_pageController.hashCode})");
     _currentDragMode = _pageController.dragMode;
     _pageController.attach(this);
     _pageController.addListener(_onMessagePageControllerChange);
@@ -1100,7 +1090,6 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
   }
 
   void _detachFromPageController() {
-    print("DETACHING FROM MESSAGE PAGE CONTROLLER (${_pageController.hashCode})");
     _pageController.removeListener(_onMessagePageControllerChange);
     _pageController.detach();
 
@@ -1167,7 +1156,6 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
   /// Shows the software keyboard, if it's hidden.
   @override
   void showSoftwareKeyboard() {
-    print("showSoftwareKeyboard()");
     // _wantsToShowKeyboardPanel = false;
     _wantsToShowSoftwareKeyboard = true;
     _pageController.softwareKeyboardController.open(viewId: _viewId);
@@ -1211,7 +1199,6 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
   /// software keyboard, if it's open.
   @override
   void showKeyboardPanel(PanelType panel) {
-    print("FloatingEditorPageScaffold - showKeyboardPanel()");
     _wantsToShowKeyboardPanel = true;
     _wantsToShowSoftwareKeyboard = false;
     _activePanel = panel;
@@ -1221,10 +1208,8 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
       // appear behind the keyboard as it closes, so that we don't have a
       // bunch of jumping around for the widgets mounted to the top of the
       // keyboard.
-      print("Jumping panel height to 100%");
       _panelHeightController.value = 1.0;
     } else {
-      print("Animating the panel height");
       _panelHeightController.forward();
     }
 
@@ -1233,7 +1218,6 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
     // TODO: Do we need to mark layout? or paint?
 
     // Notify delegate listeners.
-    print("Notifying controller listeners");
     notifyListeners();
   }
 
@@ -1252,7 +1236,6 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
     bool openKeyboard = false,
   }) {
     // Close panel.
-    print("hideKeyboardPanel()");
     _wantsToShowKeyboardPanel = false;
     _activePanel = null;
 
@@ -1291,22 +1274,13 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
   }
 
   void _onKeyboardHeightChange() {
-    print("_onKeyboardHeightChange() - ${SuperKeyboard.instance.mobileGeometry.value.keyboardHeight}");
     _updateMaxPanelHeight();
-
-    if (SuperKeyboard.instance.mobileGeometry.value.keyboardState == KeyboardState.open) {
-      print("KEYBOARD IS OPEN");
-      print(" - wants to show keyboard: $_wantsToShowSoftwareKeyboard");
-      print(" - wants to show panel: $_wantsToShowKeyboardPanel");
-      print(" - active panel: $_activePanel");
-    }
 
     if (_wantsToShowSoftwareKeyboard &&
         _wantsToShowKeyboardPanel &&
         SuperKeyboard.instance.mobileGeometry.value.keyboardState == KeyboardState.open) {
       // We kept a keyboard panel visible while the keyboard came back up. The
       // keyboard is now fully open. Get rid of the keyboard panel.
-      print("KEYBOARD IS UP - CLEARING PREVIOUS ACTIVE PANEL");
       _wantsToShowKeyboardPanel = false;
       _activePanel = null;
       notifyListeners();
@@ -1318,12 +1292,7 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
 
   void _updateMaxPanelHeight() {
     final currentKeyboardHeight = SuperKeyboard.instance.mobileGeometry.value.keyboardHeight ?? 0;
-    print("Updating max panel height...");
-    print(" - current keyboard height: $currentKeyboardHeight");
-    print(" - existing best guess: $_bestGuessMaxKeyboardHeight");
     _bestGuessMaxKeyboardHeight = max(currentKeyboardHeight, _bestGuessMaxKeyboardHeight);
-    print(" - new best guess: $_bestGuessMaxKeyboardHeight");
-    print(" - fallback: $_fallbackPanelHeight");
 
     _panelHeight = Tween(
       begin: 0.0,
@@ -1331,9 +1300,6 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
     ) //
         .chain(CurveTween(curve: Curves.easeInOut))
         .animate(_panelHeightController);
-
-    print(
-        " - chosen height: ${_bestGuessMaxKeyboardHeight > 100 ? _bestGuessMaxKeyboardHeight : _fallbackPanelHeight}");
   }
 
   void _maybeAnimatePanelClosed() {
@@ -1365,9 +1331,7 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
   @override
   void notifyListeners() {
     final listeners = Set.from(_listeners);
-    print("Notifying listeners: $listeners");
     for (final listener in listeners) {
-      print("Running listener: $listener");
       listener();
     }
   }
@@ -1552,7 +1516,6 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
   bool get isRepaintBoundary => true;
 
   void removeChild(RenderObject child, Object slot) {
-    print("SCAFFOLD RO - removeChild(): $slot");
     assert(
       _isChatScaffoldSlot(slot),
       'Render object protocol violation - tried to remove a child for an invalid slot ($slot)',
@@ -1749,7 +1712,6 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
     }
 
     final keyboardOrPanelHeight = max(max(_panelHeight.value, _keyboardHeight), _mediaQueryBottomPadding);
-    print("Keyboard or panel height: $keyboardOrPanelHeight");
 
     (_bottomSheet!.parentData! as BoxParentData).offset =
         Offset(0, size.height - _bottomSheet!.size.height - keyboardOrPanelHeight);
@@ -1778,7 +1740,6 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
 
     // (Maybe) Layout a keyboard panel, which appears where the keyboard would be.
     if (_keyboardPanel != null) {
-      print("Laying out keyboard panel render object");
       _keyboardPanel!.layout(
         constraints.copyWith(
           minHeight: _panelHeight.value,
@@ -1892,8 +1853,6 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    print("Painting scaffold...");
-    print(" - panel: $_keyboardPanel");
     messagePagePaintLog.info('---------- PAINT ------------');
     if (_content != null) {
       messagePagePaintLog.info('Painting content');
@@ -1901,10 +1860,8 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
     }
 
     if (_bottomSheet != null) {
-      print("Painting bottom sheet");
       final bottomSheetOffset = (_bottomSheet!.parentData! as BoxParentData).offset;
       messagePagePaintLog.info('Painting message editor - y-offset: $bottomSheetOffset');
-      print('Painting message editor - y-offset: $bottomSheetOffset');
       context.paintChild(
         _bottomSheet!,
         offset + bottomSheetOffset,
@@ -1912,7 +1869,6 @@ class _RenderAboveKeyboardPageScaffold<PanelType> extends RenderBox
     }
 
     if (_keyboardPanel != null) {
-      print("Painting keyboard panel - height: ${_keyboardPanel!.size.height}");
       final keyboardPanelOffset = (_keyboardPanel!.parentData! as BoxParentData).offset;
       messagePagePaintLog.info('Painting keyboard panel - y-offset: $keyboardPanelOffset');
       context.paintChild(_keyboardPanel!, offset + keyboardPanelOffset);

--- a/super_editor/lib/src/chat/chat_editor.dart
+++ b/super_editor/lib/src/chat/chat_editor.dart
@@ -189,7 +189,6 @@ class _SuperChatEditorState<PanelType> extends State<SuperChatEditor<PanelType>>
 
   @override
   void initState() {
-    print("Initializing new chat editor...");
     super.initState();
 
     _editorFocusNode = widget.editorFocusNode ?? FocusNode();
@@ -274,12 +273,10 @@ class _SuperChatEditorState<PanelType> extends State<SuperChatEditor<PanelType>>
 
   @override
   void dispose() {
-    print("Disposing chat editor...");
     SuperKeyboard.instance.mobileGeometry.removeListener(_onKeyboardChange);
 
     _isImeConnected.removeListener(_onImeConnectionChange);
     if (widget.isImeConnected == null) {
-      print("Disposing _isImeConnected");
       _isImeConnected.dispose();
     }
 
@@ -296,13 +293,10 @@ class _SuperChatEditorState<PanelType> extends State<SuperChatEditor<PanelType>>
 
     _editorFocusNode.removeListener(_onFocusChange);
     if (widget.editorFocusNode == null) {
-      print("Disposing _editorFocusNode");
       _editorFocusNode.dispose();
     }
 
     super.dispose();
-
-    print("Done with chat editor disposal");
   }
 
   void _onFocusChange() {
@@ -339,14 +333,11 @@ class _SuperChatEditorState<PanelType> extends State<SuperChatEditor<PanelType>>
   }
 
   void _onImeConnectionChange() {
-    print("_onImeConnectionChange() - is IME connected? ${_isImeConnected.value}");
-    // print("${StackTrace.current}");
     widget.pageController.collapsedMode =
         _isImeConnected.value ? MessagePageSheetCollapsedMode.intrinsic : MessagePageSheetCollapsedMode.preview;
   }
 
   void _onPageControllerChange() {
-    print("_onPageControllerChange() - _scrollController: ${_scrollController.hashCode}");
     // TODO: I added _scrollController.hashClients because we were crashing in the floating chat
     //       demo when pressing the "close keyboard" button on the toolbar. But I don't know why
     //       we lost our scrolling client when we pressed the close button.
@@ -358,7 +349,6 @@ class _SuperChatEditorState<PanelType> extends State<SuperChatEditor<PanelType>>
 
   @override
   Widget build(BuildContext context) {
-    print("Building SuperChatEditor");
     return SuperEditorFocusOnTap(
       editorFocusNode: _editorFocusNode,
       editor: widget.editor,
@@ -529,11 +519,8 @@ class SuperEditorFocusOnTap extends StatelessWidget {
   }
 
   void _selectEditor() {
-    print("Tap on editor, giving focus - focus node: ${editorFocusNode.hashCode}");
     editorFocusNode.requestFocus();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      print("Next frame after focus request. Has focus? ${editorFocusNode.hasFocus} (${editorFocusNode.hashCode})");
-    });
+    ;
 
     final endNode = editor.document.last;
     editor.execute([

--- a/super_editor/lib/src/chat/message_page_scaffold.dart
+++ b/super_editor/lib/src/chat/message_page_scaffold.dart
@@ -1,6 +1,5 @@
 import 'dart:math';
 import 'dart:ui';
-import 'dart:developer' as dev;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/physics.dart';
@@ -79,8 +78,7 @@ class MessagePageScaffold extends RenderObjectWidget {
   }
 
   @override
-  void updateRenderObject(
-      BuildContext context, RenderMessagePageScaffold renderObject) {
+  void updateRenderObject(BuildContext context, RenderMessagePageScaffold renderObject) {
     renderObject
       ..bottomSheetMinimumTopGap = bottomSheetMinimumTopGap
       ..bottomSheetMinimumHeight = bottomSheetMinimumHeight
@@ -93,8 +91,7 @@ class MessagePageScaffold extends RenderObjectWidget {
 }
 
 /// Builder that builds the content subtree within a [MessagePageScaffold].
-typedef MessagePageScaffoldContentBuilder = Widget Function(
-    BuildContext context, double bottomSpacing);
+typedef MessagePageScaffoldContentBuilder = Widget Function(BuildContext context, double bottomSpacing);
 
 /// Height sizing policy for a bottom sheet within a [MessagePageScaffold].
 enum BottomSheetMode {
@@ -121,8 +118,7 @@ enum BottomSheetMode {
 /// Controller for a [MessagePageScaffold].
 class MessagePageController with ChangeNotifier {
   MessagePageSheetHeightPolicy get sheetHeightPolicy => _sheetHeightPolicy;
-  MessagePageSheetHeightPolicy _sheetHeightPolicy =
-      MessagePageSheetHeightPolicy.minimumHeight;
+  MessagePageSheetHeightPolicy _sheetHeightPolicy = MessagePageSheetHeightPolicy.minimumHeight;
   set sheetHeightPolicy(MessagePageSheetHeightPolicy policy) {
     if (policy == _sheetHeightPolicy) {
       return;
@@ -132,15 +128,9 @@ class MessagePageController with ChangeNotifier {
     notifyListeners();
   }
 
-  bool get isPreview =>
-      _collapsedMode == MessagePageSheetCollapsedMode.preview &&
-      !isSliding &&
-      !isDragging;
+  bool get isPreview => _collapsedMode == MessagePageSheetCollapsedMode.preview && !isSliding && !isDragging;
 
-  bool get isIntrinsic =>
-      _collapsedMode == MessagePageSheetCollapsedMode.intrinsic &&
-      !isSliding &&
-      !isDragging;
+  bool get isIntrinsic => _collapsedMode == MessagePageSheetCollapsedMode.intrinsic && !isSliding && !isDragging;
 
   MessagePageSheetCollapsedMode get collapsedMode => _collapsedMode;
   var _collapsedMode = MessagePageSheetCollapsedMode.preview;
@@ -153,15 +143,9 @@ class MessagePageController with ChangeNotifier {
     notifyListeners();
   }
 
-  bool get isCollapsed =>
-      _desiredSheetMode == MessagePageSheetMode.collapsed &&
-      !isSliding &&
-      !isDragging;
+  bool get isCollapsed => _desiredSheetMode == MessagePageSheetMode.collapsed && !isSliding && !isDragging;
 
-  bool get isExpanded =>
-      _desiredSheetMode == MessagePageSheetMode.expanded &&
-      !isSliding &&
-      !isDragging;
+  bool get isExpanded => _desiredSheetMode == MessagePageSheetMode.expanded && !isSliding && !isDragging;
 
   bool get isSliding => _isSliding;
   bool _isSliding = false;
@@ -326,8 +310,7 @@ class MessagePageElement extends RenderObjectElement {
   MessagePageScaffold get widget => super.widget as MessagePageScaffold;
 
   @override
-  RenderMessagePageScaffold get renderObject =>
-      super.renderObject as RenderMessagePageScaffold;
+  RenderMessagePageScaffold get renderObject => super.renderObject as RenderMessagePageScaffold;
 
   @override
   void mount(Element? parent, Object? newSlot) {
@@ -342,8 +325,7 @@ class MessagePageElement extends RenderObjectElement {
       _contentSlot,
     );
 
-    _bottomSheet =
-        inflateWidget(widget.bottomSheetBuilder(this), _bottomSheetSlot);
+    _bottomSheet = inflateWidget(widget.bottomSheetBuilder(this), _bottomSheetSlot);
   }
 
   @override
@@ -398,8 +380,7 @@ class MessagePageElement extends RenderObjectElement {
     //
     // We don't rebuild our content widget because we only want content to
     // build during layout.
-    updateChild(
-        _bottomSheet, widget.bottomSheetBuilder(this), _bottomSheetSlot);
+    updateChild(_bottomSheet, widget.bottomSheetBuilder(this), _bottomSheetSlot);
   }
 
   void buildContent(double bottomSpacing) {
@@ -435,11 +416,8 @@ class MessagePageElement extends RenderObjectElement {
   void update(MessagePageScaffold newWidget) {
     super.update(newWidget);
 
-    _content =
-        updateChild(_content, widget.contentBuilder(this, 0), _contentSlot) ??
-            _content;
-    _bottomSheet = updateChild(
-        _bottomSheet, widget.bottomSheetBuilder(this), _bottomSheetSlot);
+    _content = updateChild(_content, widget.contentBuilder(this, 0), _contentSlot) ?? _content;
+    _bottomSheet = updateChild(_bottomSheet, widget.bottomSheetBuilder(this), _bottomSheetSlot);
   }
 
   @override
@@ -711,8 +689,7 @@ class RenderMessagePageScaffold extends RenderBox {
       _currentDesiredGlobalTopY = _controller.desiredGlobalTopY;
 
       final pageGlobalBottom = localToGlobal(Offset(0, size.height)).dy;
-      _desiredDragHeight = pageGlobalBottom -
-          max(_currentDesiredGlobalTopY!, _bottomSheetMinimumTopGap);
+      _desiredDragHeight = pageGlobalBottom - max(_currentDesiredGlobalTopY!, _bottomSheetMinimumTopGap);
       _expandedHeight = size.height - _bottomSheetMinimumTopGap;
 
       _velocityTracker.addPosition(
@@ -752,11 +729,9 @@ class RenderMessagePageScaffold extends RenderBox {
       return;
     }
 
-    print("_onDragEnd()");
     _velocityStopwatch.stop();
 
-    final velocity =
-        _velocityTracker.getVelocityEstimate()?.pixelsPerSecond.dy ?? 0;
+    final velocity = _velocityTracker.getVelocityEstimate()?.pixelsPerSecond.dy ?? 0;
 
     _startBottomSheetHeightSimulation(velocity: velocity);
   }
@@ -836,8 +811,6 @@ class RenderMessagePageScaffold extends RenderBox {
     messagePageLayoutLog.info(' - Final height: $_simulationGoalHeight');
     messagePageLayoutLog.info(' - Initial velocity: $velocity');
 
-    print(
-        "Starting simulation. Start height: $startHeight, Goal height: $_simulationGoalHeight, Initial velocity: $velocity");
     _simulation = SpringSimulation(
       const SpringDescription(
         mass: 1,
@@ -1007,8 +980,7 @@ class RenderMessagePageScaffold extends RenderBox {
       childDiagnostics.add(_content!.toDiagnosticsNode(name: 'content'));
     }
     if (_bottomSheet != null) {
-      childDiagnostics
-          .add(_bottomSheet!.toDiagnosticsNode(name: 'message_editor'));
+      childDiagnostics.add(_bottomSheet!.toDiagnosticsNode(name: 'message_editor'));
     }
 
     return childDiagnostics;
@@ -1058,8 +1030,8 @@ class RenderMessagePageScaffold extends RenderBox {
   void performLayout() {
     messagePageLayoutLog.info('---------- LAYOUT -------------');
     messagePageLayoutLog.info('Laying out RenderChatScaffold');
-    messagePageLayoutLog.info(
-        'Sheet mode: ${_controller.desiredSheetMode}, collapsed mode: ${_controller.collapsedMode}');
+    messagePageLayoutLog
+        .info('Sheet mode: ${_controller.desiredSheetMode}, collapsed mode: ${_controller.collapsedMode}');
     if (_content == null) {
       size = Size.zero;
       _bottomSheetNeedsLayout = false;
@@ -1134,8 +1106,6 @@ class RenderMessagePageScaffold extends RenderBox {
           _bottomSheetCollapsedMaximumHeight);
       final animatedHeight = _animatedHeight.clamp(minimumHeight, _bottomSheetMaximumHeight);
 
-      print(
-          "Animating: $_simulationGoalMode\n - Desired sheet mode: ${_controller.desiredSheetMode}\n - Collapsed mode? ${_controller.collapsedMode}, preview height: $_previewHeight\n - Goal height: $_simulationGoalHeight\n - Animated height: $_animatedHeight\n - Collapsed max height: $_bottomSheetCollapsedMaximumHeight\n - Min height: $minimumHeight, Max height: $_bottomSheetMaximumHeight\n - Clamped height: $animatedHeight");
       _bottomSheet!.layout(
         bottomSheetConstraints.copyWith(
           minHeight: max(animatedHeight - 1, 0),
@@ -1178,8 +1148,7 @@ class RenderMessagePageScaffold extends RenderBox {
       );
     } else {
       messagePageLayoutLog.info('>>>>>>>> Minimized');
-      messagePageLayoutLog.info(
-          'Running standard editor layout with constraints: $bottomSheetConstraints');
+      messagePageLayoutLog.info('Running standard editor layout with constraints: $bottomSheetConstraints');
       _bottomSheet!.layout(
         bottomSheetConstraints.copyWith(
           minHeight: 0,
@@ -1189,11 +1158,9 @@ class RenderMessagePageScaffold extends RenderBox {
       );
     }
 
-    (_bottomSheet!.parentData! as BoxParentData).offset =
-        Offset(0, size.height - _bottomSheet!.size.height);
+    (_bottomSheet!.parentData! as BoxParentData).offset = Offset(0, size.height - _bottomSheet!.size.height);
     _bottomSheetNeedsLayout = false;
-    messagePageLayoutLog
-        .info('Bottom sheet height: ${_bottomSheet!.size.height}');
+    messagePageLayoutLog.info('Bottom sheet height: ${_bottomSheet!.size.height}');
 
     // Now that we know the size of the message editor, build the content based
     // on the bottom spacing needed to push above the editor.
@@ -1213,11 +1180,9 @@ class RenderMessagePageScaffold extends RenderBox {
   }
 
   double _calculateBoundedIntrinsicHeight(BoxConstraints constraints) {
-    messagePageLayoutLog.info(
-        'Running dry layout on bottom sheet content to find the intrinsic height...');
+    messagePageLayoutLog.info('Running dry layout on bottom sheet content to find the intrinsic height...');
     messagePageLayoutLog.info(' - Bottom sheet constraints: $constraints');
-    messagePageLayoutLog
-        .info(' - Controller desired sheet mode: ${_controller.collapsedMode}');
+    messagePageLayoutLog.info(' - Controller desired sheet mode: ${_controller.collapsedMode}');
     _overrideSheetMode = BottomSheetMode.intrinsic;
     messagePageLayoutLog.info(' - Override sheet mode: $_overrideSheetMode');
 
@@ -1228,8 +1193,7 @@ class RenderMessagePageScaffold extends RenderBox {
         .height;
 
     _overrideSheetMode = null;
-    messagePageLayoutLog
-        .info(" - Child's self-chosen height is: $bottomSheetHeight");
+    messagePageLayoutLog.info(" - Child's self-chosen height is: $bottomSheetHeight");
     messagePageLayoutLog.info(
       " - Clamping child's height within [$_bottomSheetMinimumHeight, $_bottomSheetMaximumHeight]",
     );
@@ -1308,8 +1272,7 @@ class RenderMessagePageScaffold extends RenderBox {
   }
 }
 
-bool _isChatScaffoldSlot(Object slot) =>
-    slot == _contentSlot || slot == _bottomSheetSlot;
+bool _isChatScaffoldSlot(Object slot) => slot == _contentSlot || slot == _bottomSheetSlot;
 
 const _contentSlot = 'content';
 const _bottomSheetSlot = 'bottom_sheet';
@@ -1403,8 +1366,7 @@ class RenderMessageEditorHeight extends RenderBox
     messageEditorHeightLog.info(' - Constraints: $constraints');
 
     final ancestorChatScaffold = _findAncestorMessagePageScaffold();
-    messageEditorHeightLog
-        .info(' - Ancestor chat scaffold: $ancestorChatScaffold');
+    messageEditorHeightLog.info(' - Ancestor chat scaffold: $ancestorChatScaffold');
 
     final heightMode = ancestorChatScaffold?.bottomSheetMode;
     if (heightMode == null) {
@@ -1421,8 +1383,7 @@ class RenderMessageEditorHeight extends RenderBox
     switch (heightMode) {
       case BottomSheetMode.preview:
         // Preview mode imposes a specific height on the bottom sheet.
-        messageEditorHeightLog
-            .info(' - Desired bottom sheet preview height: $_previewHeight');
+        messageEditorHeightLog.info(' - Desired bottom sheet preview height: $_previewHeight');
 
         // We want to be a specific height. Get as close as we can.
         final constrainedHeight = constraints.constrainDimensions(
@@ -1430,8 +1391,7 @@ class RenderMessageEditorHeight extends RenderBox
           _previewHeight,
         );
 
-        messageEditorHeightLog.info(
-            ' - Constrained bottom sheet preview height: $constrainedHeight');
+        messageEditorHeightLog.info(' - Constrained bottom sheet preview height: $constrainedHeight');
         return constrainedHeight;
       case BottomSheetMode.dragging:
       case BottomSheetMode.settling:
@@ -1451,8 +1411,7 @@ class RenderMessageEditorHeight extends RenderBox
     messageEditorHeightLog.info(' - Constraints: $constraints');
 
     final ancestorChatScaffold = _findAncestorMessagePageScaffold();
-    messageEditorHeightLog
-        .info(' - Ancestor chat scaffold: $ancestorChatScaffold');
+    messageEditorHeightLog.info(' - Ancestor chat scaffold: $ancestorChatScaffold');
 
     final heightMode = ancestorChatScaffold?.bottomSheetMode;
     if (heightMode == null) {
@@ -1471,8 +1430,7 @@ class RenderMessageEditorHeight extends RenderBox
     switch (heightMode) {
       case BottomSheetMode.preview:
         // Preview mode imposes a specific height on the bottom sheet.
-        messageEditorHeightLog
-            .info(' - Forcing bottom sheet to preview height: $_previewHeight');
+        messageEditorHeightLog.info(' - Forcing bottom sheet to preview height: $_previewHeight');
 
         // We want to be a specific height. Get as close as we can.
         size = constraints.constrainDimensions(
@@ -1499,11 +1457,9 @@ class RenderMessageEditorHeight extends RenderBox
       case BottomSheetMode.expanded:
         // Whether dragging, animating, or fully expanded, these conditions
         // want to stipulate exactly how tall the bottom sheet should be.
-        messageEditorHeightLog
-            .info(' - Mode $heightMode - Filling available height');
+        messageEditorHeightLog.info(' - Mode $heightMode - Filling available height');
         if (!constraints.hasBoundedHeight) {
-          messageEditorHeightLog
-              .info('   - No bounded height was provided. Deferring to child');
+          messageEditorHeightLog.info('   - No bounded height was provided. Deferring to child');
           size = _doIntrinsicLayout(constraints);
           messageEditorHeightLog.info(' - Our reported size: $size');
           return;
@@ -1537,8 +1493,7 @@ class RenderMessageEditorHeight extends RenderBox
     BoxConstraints constraints, {
     bool doDryLayout = false,
   }) {
-    messageEditorHeightLog
-        .info(' - Measuring child intrinsic height. Constraints: $constraints');
+    messageEditorHeightLog.info(' - Measuring child intrinsic height. Constraints: $constraints');
 
     final child = this.child;
     if (child == null) {
@@ -1559,8 +1514,7 @@ class RenderMessageEditorHeight extends RenderBox
       intrinsicSize = child.size;
     }
 
-    messageEditorHeightLog
-        .info(' - Child intrinsic height: ${intrinsicSize.height}');
+    messageEditorHeightLog.info(' - Child intrinsic height: ${intrinsicSize.height}');
     return constraints.constrain(intrinsicSize);
   }
 

--- a/super_editor/lib/src/default_editor/document_ime/ime_keyboard_control.dart
+++ b/super_editor/lib/src/default_editor/document_ime/ime_keyboard_control.dart
@@ -39,7 +39,6 @@ class _SoftwareKeyboardOpenerState extends State<SoftwareKeyboardOpener> impleme
   @override
   void initState() {
     super.initState();
-    print("SoftwareKeyboardOpener - initState()");
     widget.controller?.attach(this);
   }
 

--- a/super_editor/lib/src/infrastructure/keyboard_panel_scaffold.dart
+++ b/super_editor/lib/src/infrastructure/keyboard_panel_scaffold.dart
@@ -281,7 +281,6 @@ class _KeyboardPanelScaffoldState<PanelType> extends State<KeyboardPanelScaffold
   }
 
   void _onPanelHeightChange() {
-    print("_onPanelHeightChange() - panel height: ${_panelHeight.value}, keyboard height: $_currentKeyboardHeight");
     _updateSafeArea();
     _currentBottomSpacing.value = max(_panelHeight.value, _currentKeyboardHeight);
   }
@@ -698,7 +697,6 @@ Building keyboard scaffold
               return const SizedBox.shrink();
             }
 
-            print("Building KeyboardPanelScaffold - wants to show panel? $shouldShowKeyboardPanel ($_activePanel)");
             return Positioned(
               bottom: 0,
               left: 0,
@@ -1180,6 +1178,14 @@ class _KeyboardScaffoldSafeAreaState extends State<KeyboardScaffoldSafeArea> {
   KeyboardScaffoldSafeAreaMutator? _ancestorSafeAreaScope;
   _KeyboardScaffoldSafeAreaState? _ancestorSafeArea;
 
+  // The most recent bottom insets that were applied during `build()`.
+  // This is tracked because in rare situations we end up building at a moment
+  // when we can't run `localToGlobal()`, which messes up our ability to calculate
+  // insets. Rather than return `0` when that happens, we return the most recent
+  // bottom insets in the hope that it's a more accurate number, because it was the
+  // correct number one frame earlier.
+  double _mostRecentBottomInsets = 0;
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
@@ -1247,22 +1253,37 @@ class _KeyboardScaffoldSafeAreaState extends State<KeyboardScaffoldSafeArea> {
       } catch (exception) {
         // It was found in a client app that there can be situations where at
         // this moment some render object in the ancestor chain isn't yet laid
-        // out. This results in an exception. The best we can do is return zero.
+        // out. This results in an exception. The best we can do is return the
+        // most recent correct bottom insets.
         if (isLogActive(keyboardPanelLog)) {
           keyboardPanelLog.warning(
             "KeyboardScaffoldSafeArea (${widget.debugLabel}) - Tried to measure our global bottom offset on the screen but caused an exception, likely due to an ancestor not yet being laid out.\nException: $exception\nStacktrace:\n${StackTrace.current}",
           );
         }
-        return 0;
+
+        // Schedule another build so that we can recover from an attempt to build where
+        // we couldn't look up global positioning.
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) {
+            return;
+          }
+
+          setState(() {
+            // Force a rebuild and hopefully coordinate mapping works next frame.
+          });
+        });
+
+        return _mostRecentBottomInsets;
       }
 
       if (myGlobalBottom.isNaN) {
         // We've found in a client app that under some unknown circumstances we get NaN
-        // from localToGlobal(). We're not sure why. In that case, log a warning and return zero.
+        // from localToGlobal(). We're not sure why. In that case, log a warning and return
+        // the most recent previous value for the insets.
         keyboardPanelLog.warning(
           "KeyboardScaffoldSafeArea (${widget.debugLabel}) - Tried to measure our global bottom offset on the screen but received NaN from localToGlobal(). If you're able to consistently reproduce this problem, please report it to Super Editor with the repro steps.",
         );
-        return 0;
+        return _mostRecentBottomInsets;
       }
       if (myGlobalBottom.isNegative) {
         // We haven't seen negative values here, but if we ever did receive one then our
@@ -1279,6 +1300,7 @@ class _KeyboardScaffoldSafeAreaState extends State<KeyboardScaffoldSafeArea> {
         // page animates in/out, such as a bottom sheet. While the content is at all below the
         // bottom of the screen, apply the `bottomInsets` without any adjustment. When the
         // content is fully onscreen, we can adjust it with `spaceBelowMe`.
+        _mostRecentBottomInsets = bottomInsets;
         return bottomInsets;
       }
 
@@ -1312,6 +1334,7 @@ class _KeyboardScaffoldSafeAreaState extends State<KeyboardScaffoldSafeArea> {
       });
     }
 
+    _mostRecentBottomInsets = bottomInsets;
     return bottomInsets;
   }
 }


### PR DESCRIPTION
[Super Editor][Chat] - Workaround for nuanced bottom insets calculation bug in keyboard panel scaffold (Resolves #3070)

In a client app, a KeyboardScaffoldSafeArea ends up running build at a time when localToGlobal() returns an invalid value, because at that moment we're probably in the middle of layout. We previously added some code to avoid completely blowing up when this happens, but a remaining problem is that when the current layout and paint is done, our insets continue to report 0 because build doesn't run again. This results in very wrong bottom insets because they shouldn't be 0 in the client app.

To deal with this we:

 1. When we fail to lookup localToGlobal(), schedule another build so we can update with the correct insets, and
 2. When we fail to lookup localToGlobal(), instead of returning 0, return the previous insets, because those are more likely to be correct.

## MISC
We also accumulated a bunch of `print()` statements at some point along the way. I removed those in this PR. The important part of this PR is only a few lines long.