### PR TITLE
[Super Editor] - Markdown: Serialize inline styles to valid CommonMark (Related to #2424, #2650)

### DIFF
--- a/super_editor/lib/src/infrastructure/serialization/markdown/document_to_markdown_serializer.dart
+++ b/super_editor/lib/src/infrastructure/serialization/markdown/document_to_markdown_serializer.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:attributed_text/attributed_text.dart';
 import 'package:flutter/foundation.dart';
+import 'package:markdown/markdown.dart' as md;
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/default_editor/attributions.dart';
@@ -13,6 +14,7 @@ import 'package:super_editor/src/default_editor/selection_upstream_downstream.da
 import 'package:super_editor/src/default_editor/tables/table_block.dart';
 import 'package:super_editor/src/default_editor/tasks.dart';
 import 'package:super_editor/src/default_editor/text.dart';
+import 'package:super_editor/src/infrastructure/serialization/markdown/markdown_inline_parser.dart';
 import 'package:super_editor/src/infrastructure/serialization/markdown/super_editor_syntax.dart';
 
 /// Serializes the given [doc] to Markdown text.
@@ -298,10 +300,10 @@ class ParagraphNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<Pa
 
     final Attribution? blockType = node.getMetadataValue('blockType');
 
-    final inlineMarkdown = (textSelection != null //
-            ? node.text.copyText(textSelection.start, textSelection.end)
-            : node.text)
-        .toMarkdown();
+    final textToConvert = textSelection != null //
+        ? node.text.copyText(textSelection.start, textSelection.end)
+        : node.text;
+    final inlineMarkdown = textToConvert.toMarkdown();
 
     if (blockType == header1Attribution) {
       buffer.write('# $inlineMarkdown');
@@ -332,7 +334,10 @@ class ParagraphNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<Pa
           buffer.writeln(alignmentToken);
         }
       }
-      buffer.write(inlineMarkdown);
+      // A plain paragraph has no block-level syntax of its own, so a line starting
+      // with "#", "- ", "1. ", etc., would change block type on the next parse.
+      // Serialize with those trigger characters escaped.
+      buffer.write(textToConvert.toMarkdown(escapeLineStartTriggers: true));
     }
 
     // We're not at the end of the document yet. Add a blank line after the
@@ -394,125 +399,318 @@ String? _convertAlignmentToMarkdown(String alignment) {
 
 /// Extension on [AttributedText] to serialize the [AttributedText] to a Markdown `String`.
 extension Markdown on AttributedText {
-  String toMarkdown() {
+  /// Serializes this [AttributedText] to Markdown.
+  ///
+  /// When [escapeLineStartTriggers] is `true`, a character at the start of a line
+  /// that would be re-interpreted as block-level syntax on the next parse (e.g., a
+  /// leading "#", ">", "- ", or "1. ") is backslash-escaped. Enable this when the
+  /// text is serialized as a plain paragraph. Leave it disabled when the surrounding
+  /// serializer supplies its own block-level syntax (headers, list items, tasks,
+  /// table cells, etc.), where a leading "#" can't change the block type.
+  String toMarkdown({bool escapeLineStartTriggers = false}) {
     final serializer = AttributedTextMarkdownSerializer();
-    return serializer.serialize(this);
+    return serializer.serialize(this, escapeLineStartTriggers: escapeLineStartTriggers);
   }
 }
 
-/// Serializes an [AttributedText] into markdown format
-class AttributedTextMarkdownSerializer extends AttributionVisitor {
-  late String _fullText;
-  late StringBuffer _buffer;
-  late int _bufferCursor;
+/// Serializes an [AttributedText] into markdown format.
+///
+/// The serializer guarantees, as best markdown allows, that its output re-parses
+/// back to the same styled text:
+///
+///  * Whitespace at the edges of bold/italic/strikethrough/code spans is moved
+///    outside the style markers, because CommonMark doesn't recognize a closing
+///    marker that follows whitespace — "**bold **" re-parses as plain text and
+///    the styling would silently vanish. The edge whitespace itself loses the
+///    styling, which is invisible anyway.
+///  * Overlapping (non-nested) spans are serialized by closing and re-opening
+///    styles, producing properly nested markers that CommonMark can re-parse.
+///  * Characters carrying [markdownEscapeAttribution] (characters that were
+///    backslash-escaped in the original markdown) are re-escaped on the way out.
+///  * As a safety net, the output is re-parsed and compared against the input.
+///    If the styles don't survive the round trip, markdown-significant characters
+///    are backslash-escaped and the escaped serialization is used instead. This
+///    prevents unstyled text like "3*4 and 5*6" from gaining emphasis on the
+///    next parse.
+class AttributedTextMarkdownSerializer {
+  /// Inline styles whose markers can't sit against whitespace in CommonMark.
+  ///
+  /// Spans of these attributions are trimmed to their non-whitespace core before
+  /// serialization. Underline is excluded because its proprietary `¬` marker has no
+  /// whitespace restriction, and links are excluded because link text may
+  /// legitimately start or end with spaces.
+  static const _trimmableAttributions = [
+    codeAttribution,
+    boldAttribution,
+    italicsAttribution,
+    strikethroughAttribution,
+  ];
 
-  String serialize(AttributedText attributedText) {
-    _fullText = attributedText.toPlainText();
-    _buffer = StringBuffer();
-    _bufferCursor = 0;
-    if (attributedText.toPlainText().isNotEmpty) {
-      attributedText.visitAttributions(this);
+  /// All ASCII punctuation, i.e., every character that supports backslash-escaping
+  /// in markdown. Characters carrying [markdownEscapeAttribution] are re-escaped
+  /// only if they appear in this set.
+  static final _asciiPunctuation = r'''!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~'''.codeUnits.toSet();
+
+  /// The characters that can begin inline markdown syntax. These are escaped in
+  /// non-code text when the serialization fails to round-trip without escaping.
+  static final _markdownSignificantCharacters = '*_`~[]<\\'.codeUnits.toSet();
+
+  /// Inline HTML syntaxes used when re-parsing a candidate serialization, to compare
+  /// it against the original. Extends the default set with a handler that maps hard
+  /// line breaks back to the newline characters they were serialized from.
+  static final _reparseInlineHtmlSyntaxes = [
+    ...defaultInlineHtmlSyntaxes,
+    _lineBreakHtmlSyntax,
+  ];
+
+  String serialize(AttributedText attributedText, {bool escapeLineStartTriggers = false}) {
+    final fullText = attributedText.toPlainText();
+    if (fullText.isEmpty) {
+      return '';
     }
-    return _buffer.toString();
-  }
 
-  @override
-  void visitAttributions(
-    AttributedText fullText,
-    int index,
-    Set<Attribution> startingAttributions,
-    Set<Attribution> endingAttributions,
-  ) {
-    // Write out the text between the end of the last markers, and these new markers.
-    _writeTextToBuffer(
-      fullText.toPlainText().substring(_bufferCursor, index),
+    final trimmed = _withTrimmedStyleSpans(attributedText, fullText);
+
+    final candidate = _serializeSpans(
+      trimmed,
+      fullText,
+      escapeSignificantCharacters: false,
+      escapeLineStartTriggers: escapeLineStartTriggers,
     );
-
-    // Add start markers.
-    if (startingAttributions.isNotEmpty) {
-      final markdownStyles = _sortAndSerializeAttributions(startingAttributions, AttributionVisitEvent.start);
-      // Links are different from the plain styles since they are both not NamedAttributions (and therefore
-      // can't be checked using equality comparison) and asymmetrical in markdown.
-      final linkMarker = _encodeLinkMarker(startingAttributions, AttributionVisitEvent.start);
-
-      _buffer
-        ..write(linkMarker)
-        ..write(markdownStyles);
+    if (_reparsesToSameStyles(candidate, trimmed, fullText)) {
+      return candidate;
     }
 
-    // Write out the character at this index.
-    _writeTextToBuffer(_fullText[index]);
-    _bufferCursor = index + 1;
-
-    // Add end markers.
-    if (endingAttributions.isNotEmpty) {
-      final markdownStyles = _sortAndSerializeAttributions(endingAttributions, AttributionVisitEvent.end);
-      // Links are different from the plain styles since they are both not NamedAttributions (and therefore
-      // can't be checked using equality comparison) and asymmetrical in markdown.
-      final linkMarker = _encodeLinkMarker(endingAttributions, AttributionVisitEvent.end);
-
-      _buffer
-        ..write(markdownStyles)
-        ..write(linkMarker);
-    }
+    // The un-escaped serialization doesn't survive a round trip, e.g., plain text
+    // like "3*4 and 5*6" would gain emphasis on the next parse. Escape the
+    // markdown-significant characters, and use that version if it round-trips.
+    final escaped = _serializeSpans(
+      trimmed,
+      fullText,
+      escapeSignificantCharacters: true,
+      escapeLineStartTriggers: escapeLineStartTriggers,
+    );
+    return _reparsesToSameStyles(escaped, trimmed, fullText) ? escaped : candidate;
   }
 
-  @override
-  void onVisitEnd() {
-    // When the last span has no attributions, we still have text that wasn't added to the buffer yet.
-    if (_bufferCursor <= _fullText.length - 1) {
-      _writeTextToBuffer(_fullText.substring(_bufferCursor));
-    }
-  }
-
-  /// Writes the given [text] to [_buffer].
-  ///
-  /// Separates multiple lines in a single paragraph using two spaces before each line break.
-  ///
-  /// A line ending with two or more spaces represents a hard line break,
-  /// as defined in the Markdown spec.
-  void _writeTextToBuffer(String text) {
-    final lines = text.split('\n');
-    for (int i = 0; i < lines.length; i++) {
-      if (i > 0) {
-        // Adds two spaces before line breaks.
-        // The Markdown spec defines that a line ending with two or more spaces
-        // represents a hard line break, which causes the next line to be part of
-        // the previous paragraph during deserialization.
-        _buffer.write('  ');
-        _buffer.write('\n');
-      }
-
-      _buffer.write(lines[i]);
-    }
-  }
-
-  /// Serializes style attributions into markdown syntax in a repeatable
-  /// order such that opening and closing styles match each other on
-  /// the opening and closing ends of a span.
-  static String _sortAndSerializeAttributions(Set<Attribution> attributions, AttributionVisitEvent event) {
-    const startOrder = [
-      codeAttribution,
-      boldAttribution,
-      italicsAttribution,
-      strikethroughAttribution,
-      underlineAttribution,
-    ];
-
-    final buffer = StringBuffer();
-    final encodingOrder = event == AttributionVisitEvent.start ? startOrder : startOrder.reversed;
-
-    for (final markdownStyleAttribution in encodingOrder) {
-      if (attributions.contains(markdownStyleAttribution)) {
-        buffer.write(_encodeMarkdownStyle(markdownStyleAttribution));
+  /// Returns a copy of [text] whose [_trimmableAttributions] spans are shrunk to
+  /// exclude leading/trailing whitespace. Spans that contain only whitespace are
+  /// dropped entirely — markdown has no way to style bare whitespace.
+  AttributedText _withTrimmedStyleSpans(AttributedText text, String fullText) {
+    // Coalesce abutting spans of the same attribution before trimming, so that
+    // trimming sees maximal runs. Editing can leave a bold run stored as two
+    // spans meeting at a space (e.g., after toggling bold off and back on over
+    // part of the run) — trimming each span separately would silently un-style
+    // the space at their internal boundary.
+    final spans = text.getAttributionSpansByFilter((_) => true).toList()
+      ..sort((a, b) => a.start != b.start ? a.start.compareTo(b.start) : a.end.compareTo(b.end));
+    final coalesced = <({Attribution attribution, int start, int end})>[];
+    for (final span in spans) {
+      final previousIndex = coalesced.lastIndexWhere(
+        (candidate) => candidate.attribution == span.attribution && candidate.end + 1 >= span.start,
+      );
+      if (previousIndex >= 0) {
+        final previous = coalesced[previousIndex];
+        coalesced[previousIndex] = (
+          attribution: previous.attribution,
+          start: previous.start,
+          end: span.end > previous.end ? span.end : previous.end,
+        );
+      } else {
+        coalesced.add((attribution: span.attribution, start: span.start, end: span.end));
       }
     }
 
-    return buffer.toString();
+    var changed = false;
+    final rebuiltSpans = AttributedSpans();
+    for (final span in coalesced) {
+      var start = span.start;
+      var end = span.end.clamp(0, fullText.length - 1);
+      if (_trimmableAttributions.contains(span.attribution)) {
+        while (start <= end && _isWhitespace(fullText.codeUnitAt(start))) {
+          start += 1;
+        }
+        while (end >= start && _isWhitespace(fullText.codeUnitAt(end))) {
+          end -= 1;
+        }
+      }
+      if (start > end) {
+        changed = true;
+        continue;
+      }
+      changed = changed || start != span.start || end != span.end;
+      rebuiltSpans.addAttribution(
+        newAttribution: span.attribution,
+        start: start,
+        end: end,
+        autoMerge: true,
+      );
+    }
+    return changed ? text.replaceAttributions(rebuiltSpans) : text;
   }
 
-  static String _encodeMarkdownStyle(Attribution attribution) {
-    if (attribution == codeAttribution) {
+  String _serializeSpans(
+    AttributedText text,
+    String fullText, {
+    required bool escapeSignificantCharacters,
+    required bool escapeLineStartTriggers,
+  }) {
+    final writer = _MarkdownTextWriter(escapeLineStartTriggers: escapeLineStartTriggers);
+
+    final spans = text.computeAttributionSpans().toList();
+
+    // Attributions that are currently open, in the order they were opened. Styles
+    // are closed innermost-first, and when an outer style has to close while an
+    // inner one continues, the inner style is closed and re-opened, keeping the
+    // markers properly nested.
+    final openAttributions = <Attribution>[];
+
+    for (var spanIndex = 0; spanIndex < spans.length; spanIndex += 1) {
+      final span = spans[spanIndex];
+      final styles = span.attributions.where(_isSerializedInline).toSet();
+      final isEscaped = span.attributions.contains(markdownEscapeAttribution);
+      var spanText = fullText.substring(span.start, span.end + 1);
+
+      // Close styles that end at this boundary, along with any styles that were
+      // opened after them (those are re-opened below).
+      var keepCount = 0;
+      while (keepCount < openAttributions.length && styles.contains(openAttributions[keepCount])) {
+        keepCount += 1;
+      }
+      for (var i = openAttributions.length - 1; i >= keepCount; i -= 1) {
+        writer.writeMarker(_closeMarker(openAttributions[i]));
+        openAttributions.removeAt(i);
+      }
+
+      // Open styles that start (or re-open) at this boundary. The style that
+      // extends furthest opens first so that shorter spans nest inside longer
+      // ones, e.g., bold and italics both starting at "is" in
+      // "This *is a **bold** word*" open as "*is a **bold**", not "**\*is a...".
+      final stylesToOpen = styles.where((attribution) => !openAttributions.contains(attribution)).toList()
+        ..sort((a, b) {
+          final endComparison = _attributionEnd(b, spans, spanIndex).compareTo(_attributionEnd(a, spans, spanIndex));
+          if (endComparison != 0) {
+            return endComparison;
+          }
+          return _stylePriority(a).compareTo(_stylePriority(b));
+        });
+      if (stylesToOpen.any(_trimmableAttributions.contains)) {
+        // Emphasis-like markers can't sit against whitespace. Write any leading
+        // whitespace before the opening markers. Trimming already guarantees this
+        // for span starts; this only happens when an overlapping span forced a
+        // style closed and it re-opens mid-span, e.g., at " e" in "**ab *cd***_ e_".
+        final whitespaceCount = _leadingWhitespaceCount(spanText);
+        if (whitespaceCount > 0) {
+          writer.writeText(spanText.substring(0, whitespaceCount));
+          spanText = spanText.substring(whitespaceCount);
+        }
+      }
+      for (final attribution in stylesToOpen) {
+        writer.writeMarker(_openMarker(attribution));
+        openAttributions.add(attribution);
+      }
+
+      if (spanText.isEmpty) {
+        continue;
+      }
+      if (isEscaped) {
+        // These characters were backslash-escaped in the original markdown.
+        writer.writeText(spanText, escapeCharacters: _asciiPunctuation);
+      } else if (escapeSignificantCharacters && !styles.contains(codeAttribution)) {
+        writer.writeText(spanText, escapeCharacters: _markdownSignificantCharacters);
+      } else {
+        writer.writeText(spanText);
+      }
+    }
+
+    for (var i = openAttributions.length - 1; i >= 0; i -= 1) {
+      writer.writeMarker(_closeMarker(openAttributions[i]));
+    }
+
+    return writer.toString();
+  }
+
+  /// Whether serializing [markdown] and parsing it again produces the styles in
+  /// [expected] — the bar every serialization must meet for styling and text to
+  /// survive a save/load round trip.
+  bool _reparsesToSameStyles(String markdown, AttributedText expected, String expectedText) {
+    AttributedText reparsed;
+    try {
+      reparsed = parseInlineMarkdown(
+        markdown,
+        inlineHtmlSyntaxes: _reparseInlineHtmlSyntaxes,
+      );
+    } catch (_) {
+      return false;
+    }
+
+    if (reparsed.toPlainText() != expectedText) {
+      return false;
+    }
+
+    for (var i = 0; i < expectedText.length; i += 1) {
+      final expectedStyles = expected.getAllAttributionsAt(i).where(_isSerializedInline).toSet();
+      final reparsedStyles = reparsed.getAllAttributionsAt(i).where(_isSerializedInline).toSet();
+      if (!setEquals(expectedStyles, reparsedStyles)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Maps hard line breaks in a re-parsed candidate serialization back to the
+  /// newline they were serialized from, so the comparison in
+  /// [_reparsesToSameStyles] sees the same plain text.
+  static AttributedText? _lineBreakHtmlSyntax(md.Element element, AttributedText text) {
+    if (element.tag != 'br') {
+      return null;
+    }
+    return AttributedText('\n');
+  }
+
+  static bool _isSerializedInline(Attribution attribution) =>
+      attribution == codeAttribution ||
+      attribution == boldAttribution ||
+      attribution == italicsAttribution ||
+      attribution == strikethroughAttribution ||
+      attribution == underlineAttribution ||
+      attribution is LinkAttribution;
+
+  /// The last text offset covered by [attribution], scanning contiguously
+  /// forward from the span at [fromIndex].
+  static int _attributionEnd(Attribution attribution, List<MultiAttributionSpan> spans, int fromIndex) {
+    var end = spans[fromIndex].end;
+    for (var i = fromIndex + 1; i < spans.length; i += 1) {
+      if (!spans[i].attributions.contains(attribution)) {
+        break;
+      }
+      end = spans[i].end;
+    }
+    return end;
+  }
+
+  /// Nesting priority when multiple styles open at the same offset — lower values
+  /// sit outside higher ones.
+  static int _stylePriority(Attribution attribution) {
+    if (attribution is LinkAttribution) {
+      return 0;
+    } else if (attribution == codeAttribution) {
+      return 1;
+    } else if (attribution == boldAttribution) {
+      return 2;
+    } else if (attribution == italicsAttribution) {
+      return 3;
+    } else if (attribution == strikethroughAttribution) {
+      return 4;
+    } else {
+      return 5;
+    }
+  }
+
+  static String _openMarker(Attribution attribution) {
+    if (attribution is LinkAttribution) {
+      return '[';
+    } else if (attribution == codeAttribution) {
       return '`';
     } else if (attribution == boldAttribution) {
       return '**';
@@ -527,21 +725,131 @@ class AttributedTextMarkdownSerializer extends AttributionVisitor {
     }
   }
 
-  /// Checks for the presence of a link in the attributions and returns the characters necessary to represent it
-  /// at the open or closing boundary of the attribution, depending on the event.
-  static String _encodeLinkMarker(Set<Attribution> attributions, AttributionVisitEvent event) {
-    final linkAttributions = attributions.whereType<LinkAttribution?>();
-    if (linkAttributions.isNotEmpty) {
-      final linkAttribution = linkAttributions.first as LinkAttribution;
+  static String _closeMarker(Attribution attribution) {
+    if (attribution is LinkAttribution) {
+      return '](${attribution.plainTextUri})';
+    } else {
+      return _openMarker(attribution);
+    }
+  }
 
-      if (event == AttributionVisitEvent.start) {
-        return '[';
-      } else {
-        return '](${linkAttribution.plainTextUri})';
+  static int _leadingWhitespaceCount(String text) {
+    var count = 0;
+    while (count < text.length && _isWhitespace(text.codeUnitAt(count))) {
+      count += 1;
+    }
+    return count;
+  }
+
+  static bool _isWhitespace(int codeUnit) =>
+      codeUnit == 0x20 || codeUnit == 0x09 || codeUnit == 0x0A || codeUnit == 0x0D;
+}
+
+/// Accumulates serialized markdown text, handling hard line breaks, backslash
+/// escaping, and escaping of block-level syntax at line starts.
+class _MarkdownTextWriter {
+  _MarkdownTextWriter({required this.escapeLineStartTriggers});
+
+  /// Whether to backslash-escape characters at the start of a line that would be
+  /// re-interpreted as block-level syntax (headings, list bullets, blockquotes,
+  /// thematic breaks, fences) when the markdown is parsed again.
+  final bool escapeLineStartTriggers;
+
+  final _buffer = StringBuffer();
+  bool _isAtLineStart = true;
+
+  /// Ordered list markers are neutralized by escaping the delimiter after the
+  /// digits ("1\. "), because a backslash before a digit is not an escape.
+  static final _orderedListPattern = RegExp(r'^ {0,3}\d{1,9}[.)][ \t]');
+
+  /// Block-level syntax that a plain paragraph line must not start with. For all
+  /// of these, escaping the first non-space character neutralizes the syntax.
+  static final _blockTriggerPatterns = <RegExp>[
+    RegExp(r'^ {0,3}#{1,6}(?:[ \t]|$)'), // ATX heading
+    RegExp(r'^ {0,3}>'), // blockquote
+    RegExp(r'^ {0,3}[-*+][ \t]'), // bullet list item
+    RegExp(r'^ {0,3}(?:-[ \t]*){3,}$'), // thematic break, e.g. "---"
+    RegExp(r'^ {0,3}(?:\*[ \t]*){3,}$'), // thematic break, e.g. "***"
+    RegExp(r'^ {0,3}(?:_[ \t]*){3,}$'), // thematic break, e.g. "___"
+    RegExp(r'^ {0,3}=+[ \t]*$'), // setext heading underline
+    RegExp(r'^ {0,3}`{3,}'), // code fence
+    RegExp(r'^ {0,3}~{3,}'), // code fence
+  ];
+
+  void writeMarker(String marker) {
+    _buffer.write(marker);
+    if (marker.isNotEmpty) {
+      _isAtLineStart = false;
+    }
+  }
+
+  /// Writes the given [text], escaping any characters whose code units appear in
+  /// [escapeCharacters] with a leading backslash.
+  ///
+  /// Separates multiple lines in a single paragraph using two spaces before each
+  /// line break. A line ending with two or more spaces represents a hard line
+  /// break, as defined in the Markdown spec.
+  void writeText(String text, {Set<int>? escapeCharacters}) {
+    final lines = text.split('\n');
+    for (int i = 0; i < lines.length; i++) {
+      if (i > 0) {
+        // Adds two spaces before line breaks.
+        // The Markdown spec defines that a line ending with two or more spaces
+        // represents a hard line break, which causes the next line to be part of
+        // the previous paragraph during deserialization.
+        _buffer.write('  ');
+        _buffer.write('\n');
+        _isAtLineStart = true;
+      }
+      _writeLine(lines[i], escapeCharacters);
+    }
+  }
+
+  void _writeLine(String line, Set<int>? escapeCharacters) {
+    if (line.isEmpty) {
+      return;
+    }
+
+    var escapeAtIndex = -1;
+    if (_isAtLineStart && escapeLineStartTriggers) {
+      escapeAtIndex = _findBlockTriggerIndex(line);
+    }
+
+    if (escapeCharacters == null && escapeAtIndex < 0) {
+      _buffer.write(line);
+    } else {
+      for (var i = 0; i < line.length; i += 1) {
+        final codeUnit = line.codeUnitAt(i);
+        if (i == escapeAtIndex || (escapeCharacters?.contains(codeUnit) ?? false)) {
+          _buffer.write(r'\');
+        }
+        _buffer.writeCharCode(codeUnit);
       }
     }
-    return "";
+    _isAtLineStart = false;
   }
+
+  static int _findBlockTriggerIndex(String line) {
+    final orderedListMatch = _orderedListPattern.firstMatch(line);
+    if (orderedListMatch != null) {
+      // Escape the "." or ")" that follows the digits.
+      return orderedListMatch.end - 2;
+    }
+    for (final pattern in _blockTriggerPatterns) {
+      if (pattern.hasMatch(line)) {
+        // Escape the first non-space character.
+        var index = 0;
+        while (index < line.length && line.codeUnitAt(index) == 0x20) {
+          index += 1;
+        }
+        return index;
+      }
+    }
+    return -1;
+  }
+
+  @override
+  String toString() => _buffer.toString();
 }
 
 /// [DocumentNodeMarkdownSerializer], which serializes Markdown headers to

--- a/super_editor/lib/src/infrastructure/serialization/markdown/markdown_inline_parser.dart
+++ b/super_editor/lib/src/infrastructure/serialization/markdown/markdown_inline_parser.dart
@@ -36,6 +36,7 @@ AttributedText parseInlineMarkdown(
 }
 
 final defaultSuperEditorInlineSyntaxes = [
+  PreservedEscapeSyntax(), // must run before the markdown package's EscapeSyntax, which discards the backslash
   SingleStrikethroughSyntax(), // this needs to be before md.StrikethroughSyntax to be recognized
   md.StrikethroughSyntax(),
   UnderlineSyntax(),
@@ -43,10 +44,37 @@ final defaultSuperEditorInlineSyntaxes = [
 ];
 
 final defaultNonSuperEditorInlineSyntaxes = [
+  PreservedEscapeSyntax(), // must run before the markdown package's EscapeSyntax, which discards the backslash
   SingleStrikethroughSyntax(), // this needs to be before md.StrikethroughSyntax to be recognized
   md.StrikethroughSyntax(),
   UnderlineSyntax(),
 ];
+
+/// Attribution applied to characters that were backslash-escaped in the Markdown
+/// source, e.g., the `*` in "3\*4".
+///
+/// The parser strips the backslash so the user sees the bare character, and the
+/// serializer re-emits the backslash for any character carrying this attribution.
+/// Without it, "3\*4" would save as "3*4" and the markers could be re-interpreted
+/// as emphasis on the next parse.
+const markdownEscapeAttribution = NamedAttribution('markdownEscape');
+
+/// Matches a backslash-escaped ASCII punctuation character, like the markdown
+/// package's own `EscapeSyntax`, but wraps the escaped character in an element
+/// so that the escape survives the round trip as [markdownEscapeAttribution].
+class PreservedEscapeSyntax extends md.InlineSyntax {
+  PreservedEscapeSyntax()
+      : super(
+          r'''\\([!"#$%&'()*+,\-./:;<=>?@\[\\\]^_`{|}~])''',
+          startCharacter: 0x5C, // backslash
+        );
+
+  @override
+  bool onMatch(md.InlineParser parser, Match match) {
+    parser.addNode(md.Element.text('mdEscape', match[1]!));
+    return true;
+  }
+}
 
 /// Parses inline markdown content.
 ///
@@ -111,6 +139,7 @@ const defaultInlineHtmlSyntaxes = [
   strikethroughHtmlSyntax,
   anchorHtmlSyntax,
   codeInlineHtmlSyntax,
+  escapedCharacterHtmlSyntax,
 ];
 
 typedef InlineHtmlSyntax = AttributedText? Function(md.Element element, AttributedText text);
@@ -183,6 +212,18 @@ AttributedText? codeInlineHtmlSyntax(md.Element element, AttributedText text) {
   return text
     ..addAttribution(
       codeAttribution,
+      SpanRange(0, text.length - 1),
+    );
+}
+
+AttributedText? escapedCharacterHtmlSyntax(md.Element element, AttributedText text) {
+  if (element.tag != 'mdEscape') {
+    return null;
+  }
+
+  return text
+    ..addAttribution(
+      markdownEscapeAttribution,
       SpanRange(0, text.length - 1),
     );
 }

--- a/super_editor/test/infrastructure/serialization/markdown/attributed_text_markdown_test.dart
+++ b/super_editor/test/infrastructure/serialization/markdown/attributed_text_markdown_test.dart
@@ -51,20 +51,135 @@ void main() {
       // turns out that Markdown doesn't know how to parse overlapping styles,
       // so we can't parse this text from Markdown, but we can still test our
       // ability to serialize overlapping styles.
-      expect(
-        AttributedText(
-          "This is overlapping styles.",
-          AttributedSpans(
-            attributions: [
-              const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.start),
-              const SpanMarker(attribution: boldAttribution, offset: 13, markerType: SpanMarkerType.end),
-              const SpanMarker(attribution: italicsAttribution, offset: 11, markerType: SpanMarkerType.start),
-              const SpanMarker(attribution: italicsAttribution, offset: 18, markerType: SpanMarkerType.end),
-            ],
-          ),
-        ).toMarkdown(),
-        "This is **ove*rla**pping* styles.",
+      //
+      // Overlapping styles can't be expressed directly in Markdown. The
+      // serializer closes and re-opens the inner style so that the markers
+      // nest properly, and the output re-parses to the same styled text.
+      final text = AttributedText(
+        "This is overlapping styles.",
+        AttributedSpans(
+          attributions: [
+            const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.start),
+            const SpanMarker(attribution: boldAttribution, offset: 13, markerType: SpanMarkerType.end),
+            const SpanMarker(attribution: italicsAttribution, offset: 11, markerType: SpanMarkerType.start),
+            const SpanMarker(attribution: italicsAttribution, offset: 18, markerType: SpanMarkerType.end),
+          ],
+        ),
       );
+
+      final markdown = text.toMarkdown();
+      expect(markdown, "This is **ove*rla****pping* styles.");
+
+      // The bar for overlapping styles: the output must re-parse to the same
+      // styled text.
+      final reparsed = parseInlineMarkdown(markdown);
+      expect(reparsed.toPlainText(), "This is overlapping styles.");
+      for (int i = 0; i < reparsed.length; i += 1) {
+        expect(
+          reparsed.getAllAttributionsAt(i).contains(boldAttribution),
+          8 <= i && i <= 13,
+          reason: "bold at index $i",
+        );
+        expect(
+          reparsed.getAllAttributionsAt(i).contains(italicsAttribution),
+          11 <= i && i <= 18,
+          reason: "italics at index $i",
+        );
+      }
+    });
+  });
+
+  group("AttributedText markdown round-trips", () {
+    test("bold span with trailing whitespace is trimmed to valid CommonMark", () {
+      // A user can select "bold " (including the space) and press the bold
+      // button. Serializing the markers around the space would produce
+      // "**bold ** text", which no CommonMark parser re-parses as bold — the
+      // styling would silently vanish on the next load.
+      final text = AttributedText("bold text");
+      text.addAttribution(boldAttribution, const SpanRange(0, 4)); // "bold ", including the space.
+
+      expect(text.toMarkdown(), "**bold** text");
+    });
+
+    test("bold span with leading whitespace is trimmed to valid CommonMark", () {
+      final text = AttributedText("some bold");
+      text.addAttribution(boldAttribution, const SpanRange(4, 8)); // " bold", including the space.
+
+      expect(text.toMarkdown(), "some **bold**");
+    });
+
+    test("whitespace-only bold span is dropped", () {
+      final text = AttributedText("a b");
+      text.addAttribution(boldAttribution, const SpanRange(1, 1)); // just the space
+
+      expect(text.toMarkdown(), "a b");
+    });
+
+    test("adjacent bold spans serialize as a single span", () {
+      final text = AttributedText("ab");
+      text.addAttribution(boldAttribution, const SpanRange(0, 0));
+      text.addAttribution(boldAttribution, const SpanRange(1, 1));
+
+      expect(text.toMarkdown(), "**ab**");
+    });
+
+    test("backslash escapes survive the round trip", () {
+      // Parsing strips the backslash for display ("3*4"), records the escape as
+      // an attribution, and serialization re-emits the backslash. Without this,
+      // "3\*4 and a\_b" would save as "3*4 and a_b" and the bare markers could
+      // be re-interpreted as emphasis on a later parse.
+      final parsed = parseInlineMarkdown(r"3\*4 and a\_b");
+      expect(parsed.toPlainText(), "3*4 and a_b");
+      expect(parsed.toMarkdown(), r"3\*4 and a\_b");
+    });
+
+    test("unescaped plain text that would gain styling is escaped on serialization", () {
+      // "3*4 and 5*6" contains a valid emphasis pair. Serializing it verbatim
+      // would corrupt the text on the next parse: 3<em>4 and 5</em>6.
+      final text = AttributedText("3*4 and 5*6");
+
+      final markdown = text.toMarkdown();
+      expect(markdown, r"3\*4 and 5\*6");
+
+      final reparsed = parseInlineMarkdown(markdown);
+      expect(reparsed.toPlainText(), "3*4 and 5*6");
+      expect(reparsed.getAttributionSpansByFilter((a) => a == italicsAttribution), isEmpty);
+    });
+
+    test("invalid emphasis markers pass through without escaping", () {
+      // "**bold ** text" never re-parses as bold (the closing marker follows a
+      // space), so the serializer must not touch it.
+      final text = AttributedText("**bold ** text");
+
+      expect(text.toMarkdown(), "**bold ** text");
+    });
+
+    test("intraword underscores pass through without escaping", () {
+      final text = AttributedText("use my_variable_name and a_b_c here");
+
+      expect(text.toMarkdown(), "use my_variable_name and a_b_c here");
+    });
+
+    test("plain paragraph line starting with block syntax is escaped", () {
+      expect(
+        AttributedText("# not a heading").toMarkdown(escapeLineStartTriggers: true),
+        r"\# not a heading",
+      );
+      expect(
+        AttributedText("- not a list item").toMarkdown(escapeLineStartTriggers: true),
+        r"\- not a list item",
+      );
+      expect(
+        AttributedText("1. not a list item").toMarkdown(escapeLineStartTriggers: true),
+        r"1\. not a list item",
+      );
+      expect(
+        AttributedText("> not a blockquote").toMarkdown(escapeLineStartTriggers: true),
+        r"\> not a blockquote",
+      );
+
+      // Without opt-in (headers, list items, table cells), nothing is escaped.
+      expect(AttributedText("# still a heading").toMarkdown(), "# still a heading");
     });
   });
 }

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -533,7 +533,7 @@ void main() {
           expect(
             document,
             equalsMarkdown(
-              "This is the first** node in a document.**",
+              "This is the first **node in a document.**",
             ),
           );
 
@@ -547,7 +547,7 @@ void main() {
           expect(
             document,
             equalsMarkdown(
-              "**This is the first**** node in a document.**",
+              "**This is the first node in a document.**",
             ),
           );
         });
@@ -1276,7 +1276,7 @@ void main() {
           expect(
             document,
             equalsMarkdown(
-              "This is the first **node in a document.**\n\n**This is the second node in a document.**\n\n**This is the third **node in a document.",
+              "This is the first **node in a document.**\n\n**This is the second node in a document.**\n\n**This is the third** node in a document.",
             ),
           );
 
@@ -1415,7 +1415,7 @@ void main() {
           await tester.typeImeText(" bold");
 
           // Ensure the bold attribution is applied.
-          expect(document, equalsMarkdown("This text should be** bold**"));
+          expect(document, equalsMarkdown("This text should be **bold**"));
         });
       });
 

--- a/super_editor/test/super_editor/text_entry/ime/ime_ios_exceptional_cases_test.dart
+++ b/super_editor/test/super_editor/text_entry/ime/ime_ios_exceptional_cases_test.dart
@@ -204,7 +204,7 @@ void main() {
           ], getter: imeClientGetter);
 
           // Ensure the text was replaced and the style was preserved.
-          expect(testContext.document, equalsMarkdown('**Fixed **'));
+          expect(testContext.document, equalsMarkdown('**Fixed** '));
         });
       });
 


### PR DESCRIPTION
## What this does

Rewrites `AttributedTextMarkdownSerializer` so that its Markdown output re-parses to the same styled text. Today, several common inputs serialize to Markdown that no CommonMark parser (including this package's own parser) reads back with the same styling, so styles silently vanish or change on the next load.

- **Whitespace at span edges** — a bold span that includes a trailing space serializes as `**bold ** text`, which is not valid CommonMark emphasis (the closing delimiter can't be preceded by whitespace, per [CommonMark spec §6.2, left-/right-flanking delimiter runs](https://spec.commonmark.org/0.31.2/#left-flanking-delimiter-run)). The serializer now moves edge whitespace outside the markers: `**bold** text`. This is easy to hit in practice: mobile keyboard word suggestions insert a trailing space, which ends up inside the styled span (#2650). Related to #2424 and the earlier attempt in #2452 — the renderer comparison table in #2452 (GitHub, flutter_markdown, VSCode, Typora, StackEdit, Dillinger all refuse space-adjacent delimiters) covers the "is this really invalid?" question that stalled that PR.
- **Backslash escapes** — parsing `3\*4` now records a `markdownEscape` attribution on the `*`, and serialization re-emits the backslash. Previously the escape was destroyed on the first round trip and the bare `*` could become an emphasis delimiter on the next parse.
- **Overlapping (non-nested) spans** — serialized by closing and re-opening styles so markers nest properly, and the output re-parses to the same attributions. Styles opening at the same offset open longest-span-first. Adjacent same-style spans merge instead of emitting `**a****b**`.
- **Safety net** — the serializer re-parses its own output and compares attributions; if the styles don't survive, it backslash-escapes markdown-significant characters and uses that form instead (protects plain text like `3*4 and 5*6` from gaining emphasis on the next parse).
- **Block-trigger escaping (opt-in)** — plain paragraphs serialize with line-leading block syntax escaped (`\# not a heading`), so a paragraph that merely starts with `#`, `- `, `1. `, `>`, a fence, or a thematic break doesn't change block type on the next parse. Node serializers that supply their own block syntax (headers, list items, table cells) leave this off.
- **Abutting spans coalesce before trimming** — editing can leave one bold run stored as two spans meeting at a space (toggle bold off and back on over part of a run); trimming each span separately would silently un-style that internal space. Runs are coalesced first, so only the true edges of a styled run are trimmed.

Four existing test expectations encoded the invalid serializations (`text** bold**`, `**a****b**`, `**Fixed **` — that last one, in `ime_ios_exceptional_cases_test.dart`, is exactly the #2650 keyboard-suggestion scenario) and are updated to the valid forms, which re-parse to the same styled text.

## What this doesn't change

Strikethrough still serializes as single `~` and underline as `¬` in this PR; moving those to GFM `~~` / `<u>` is split into the follow-up PR so this one stays reviewable.

## Tests

New round-trip cases in `attributed_text_markdown_test.dart` covering each bullet above. `flutter test` passes for the package.

## Context

Extracted from [MemNote](https://memnote.randomfact.com)'s super_editor fork, where these fixes shipped after we traced note corruption to serialize/parse round trips (every save/load cycle compounded the damage).

*This is PR 1 of a 6-PR series upstreaming our Markdown codec fixes; each is independently revertable but they apply in order. I'll rebase the rest as predecessors merge.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
