### PR TITLE
[SuperEditor][iOS] Fix long-press selection latching on forever

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -361,6 +361,16 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
   bool get _isLongPressInProgress => _longPressStrategy != null;
   IosLongPressSelectionStrategy? _longPressStrategy;
 
+  /// Whether a long-press selection was ended during the gesture that's still
+  /// in flight.
+  ///
+  /// A long-press that ends without a drag is torn down by whichever of
+  /// [_onPanCancel] and [_onTapUp] runs first, and both can run for the same
+  /// pointer. This flag lets the second one know the work is already done, so
+  /// that [_onTapUp] doesn't treat the release as a fresh tap on the
+  /// long-press selection and toggle the just-revealed toolbar back off.
+  bool _didEndLongPressDuringCurrentGesture = false;
+
   // Cached view metrics to ignore unnecessary didChangeMetrics calls.
   Size? _lastSize;
   ViewPadding? _lastInsets;
@@ -439,6 +449,14 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+
+    // The long-press timer is armed on every tap-down and lives outside the
+    // gesture arena, so it can outlive this State. Its callback touches both
+    // `_interactor.currentContext` (gone) and the controls controller (owned by
+    // an ancestor scope, so very much alive) — leaving a magnifier showing that
+    // no interactor is left to hide.
+    _tapDownLongPressTimer?.cancel();
+    _tapDownLongPressTimer = null;
 
     _controlsController!.floatingCursorController.removeListener(_floatingCursorListener);
     _controlsController!.floatingCursorController.cursorGeometryInViewport
@@ -586,6 +604,7 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
 
   void _onTapDown(TapDownDetails details) {
     _globalTapDownOffset = details.globalPosition;
+    _didEndLongPressDuringCurrentGesture = false;
     _tapDownLongPressTimer?.cancel();
     if (!disableLongPressSelectionForSuperlist) {
       _tapDownLongPressTimer = Timer(kLongPressTimeout, _onLongPressDown);
@@ -644,9 +663,31 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     // Stop waiting for a long-press to start.
     _globalTapDownOffset = null;
     _tapDownLongPressTimer?.cancel();
+    _tapDownLongPressTimer = null;
     _controlsController!
       ..hideMagnifier()
       ..blinkCaret();
+
+    // This release concludes a long-press selection rather than being a fresh
+    // tap, so end the long-press (unless [_onPanCancel] already did, which
+    // happens when the pan recognizer sees the same pointer go away) and leave
+    // the resulting selection and toolbar alone. Falling through would treat
+    // the release as a tap inside the selection and toggle the toolbar that
+    // ending the long-press just revealed straight back off.
+    if (_isLongPressInProgress || _didEndLongPressDuringCurrentGesture) {
+      if (_isLongPressInProgress) {
+        _onLongPressEnd();
+      }
+      _didEndLongPressDuringCurrentGesture = false;
+
+      // Lifting off a long-press always leaves the toolbar up, including when
+      // the selection it produced is collapsed — long-pressing an empty
+      // paragraph, for example. [_onLongPressEnd] only reveals the toolbar for
+      // expanded selections, because the drag-selection path it also serves
+      // shouldn't pop a toolbar for a caret.
+      _controlsController!.showToolbar();
+      return;
+    }
 
     editorGesturesLog.info("Tap down on document");
     final docOffset = _interactorOffsetToDocumentOffset(details.localPosition);
@@ -1195,6 +1236,17 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
 
     if (_dragMode != null) {
       _onDragSelectionEnd();
+    } else if (_isLongPressInProgress) {
+      // A long-press selection started, but the pointer was taken away before
+      // it ever became a drag — so `_dragMode` was never set, and the usual
+      // teardown ([_onDragSelectionEnd] -> [_onLongPressEnd]) can't run.
+      //
+      // Leaving it in progress is what strands the editor: `_longPressStrategy`
+      // stays non-null, so `EagerPanGestureRecognizer.shouldAccept` claims the
+      // *next*, unrelated pan as a long-press drag-selection — magnifier up,
+      // auto-scroller running — with no matching drag end to take either back
+      // down. Android ends the long-press on this same signal.
+      _onLongPressEnd();
     }
     _controlsController!.handleBeingDragged.value = null;
   }
@@ -1214,6 +1266,7 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     _longPressStrategy!.onLongPressEnd();
     _longPressStrategy = null;
     _dragMode = null;
+    _didEndLongPressDuringCurrentGesture = true;
 
     _updateOverlayControlsAfterFinishingDragSelection();
   }
@@ -1226,7 +1279,11 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
 
   void _updateOverlayControlsAfterFinishingDragSelection() {
     _controlsController!.hideMagnifier();
-    if (!widget.selection.value!.isCollapsed) {
+    // Null-safe on the selection: this now also runs from [_onTapUp] and
+    // [_onPanCancel], which can fire after the selection was cleared (e.g.
+    // focus moved elsewhere). A null-assert here would turn a stale long-press
+    // into a crash.
+    if (widget.selection.value?.isCollapsed == false) {
       _controlsController!.showToolbar();
     }
   }

--- a/super_editor/test/super_editor/mobile/super_editor_ios_selection_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_selection_test.dart
@@ -121,6 +121,43 @@ void main() {
           _expectHandlesAndToolbar();
         });
 
+        testWidgetsOnIos("stops selecting by long-press when the press is cancelled", (tester) async {
+          await _pumpAppWithLongText(tester);
+
+          // Long press down on the middle of "conse|ctetur", so a long-press
+          // selection starts, and then have the tap cancelled instead of
+          // released - which is what happens when another recognizer in the
+          // arena takes the pointer away from the document.
+          final longPress = await tester.longPressDownInParagraph("1", 33);
+          await tester.pumpAndSettle();
+          expect(SuperEditorInspector.findDocumentSelection(), _wordConsecteturSelection);
+
+          await longPress.cancel();
+          await tester.pumpAndSettle();
+
+          // Now drag somewhere else in the document.
+          //
+          // The long press never became a drag, so nothing used to clear it.
+          // The interactor stayed in long-press mode, which made
+          // `EagerPanGestureRecognizer.shouldAccept` claim this unrelated pan
+          // as a long-press drag-selection: the selection expanded by word, the
+          // magnifier came up, and the drag auto-scroller started - none of
+          // which could be undone, because only the end of a drag-selection
+          // takes them back down.
+          final drag = await tester.startGesture(tester.getCenter(find.byType(SuperEditor)));
+          await tester.pump(kTapMinTime);
+          for (int i = 0; i < 5; i += 1) {
+            await drag.moveBy(const Offset(20, 0));
+            await tester.pump();
+          }
+
+          expect(find.byType(IOSRoundedRectangleMagnifyingGlass), findsNothing);
+          expect(SuperEditorInspector.findDocumentSelection(), _wordConsecteturSelection);
+
+          await drag.up();
+          await tester.pumpAndSettle();
+        });
+
         testWidgetsOnIos("does nothing with hack global property", (tester) async {
           disableLongPressSelectionForSuperlist = true;
           addTearDown(() => disableLongPressSelectionForSuperlist = false);


### PR DESCRIPTION
## Problem

On iOS, `IosDocumentTouchInteractor` can get permanently stuck in long-press selection mode: the magnifier stays up, every subsequent drag anywhere in the document selects text by word instead of doing what it should, and the drag auto-scroller keeps scrolling. Nothing clears it — the editor only recovers when something rebuilds the interactor.

## Cause

`_onLongPressDown` starts a long-press selection and shows the magnifier, but it does not set `_dragMode` — only `_onPanStart` does. The only place that ends a long-press, `_onLongPressEnd`, is reachable exclusively through `_onDragSelectionEnd`, which requires that `_dragMode`.

So a long-press that never becomes a drag is never torn down. `_longPressStrategy` stays non-null, and because `EagerPanGestureRecognizer.shouldAccept` returns `true` whenever `_isLongPressInProgress`, the *next unrelated pan* is claimed as a long-press drag-selection — with no matching drag end to undo any of it.

This is reachable whenever the pointer is taken away from the interactor after `kLongPressTimeout` has already elapsed: another recognizer wins the arena, or an overlapping widget's `HitTestBehavior` changes mid-gesture. In our app it reproduces by moving focus between two text surfaces on the same screen, which flips the document components between `opaque` and `translucent` hit-testing.

`AndroidDocumentTouchInteractor` does not have this bug — its `_onTapUp` and `_onPanCancel` both end an in-progress long-press. This PR mirrors that on iOS.

## Changes

- `_onPanCancel` ends the long-press even when no drag started.
- `_onTapUp` ends it too, and returns early instead of running its ordinary tap handling — otherwise the release is treated as a tap inside the long-press selection and toggles the just-revealed toolbar straight back off. `_didEndLongPressDuringCurrentGesture` coordinates the two callbacks, since both can fire for the same pointer and `_onPanCancel` runs first.
- The toolbar is still shown on release when the long-press produced a *collapsed* selection (long-pressing an empty paragraph). `_onLongPressEnd` alone only reveals it for expanded selections, because the drag-selection path it also serves shouldn't pop a toolbar for a caret.
- `_tapDownLongPressTimer` is cancelled in `dispose()`. It's armed on every tap-down and lives outside the gesture arena, so it can outlive the `State` — its callback then touches `_interactor.currentContext` and raises a magnifier on the `SuperEditorIosControlsController`, which is owned by an ancestor scope and very much alive, with no interactor left to lower it.
- `_updateOverlayControlsAfterFinishingDragSelection` is now null-safe on the selection, since it also runs from the tap-up and pan-cancel paths where the selection may already be gone.

## Testing

New test in `super_editor_ios_selection_test.dart` covering the cancelled-press case: long-press to select a word, cancel the pointer instead of releasing it, then drag elsewhere. Without the fix the drag raises the magnifier and takes over the selection.

Full `super_editor` suite on this branch: **5758 passing, 0 failing.**